### PR TITLE
fix: Memory leak — cap _seen_content and _seen_message_ids with BoundedSet

### DIFF
--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -15,6 +15,7 @@ from g3lobster.chat.auth import get_authenticated_service
 from g3lobster.chat.commands import handle as handle_command
 from g3lobster.cli.parser import get_content_id
 from g3lobster.tasks.types import Task, TaskStatus
+from g3lobster.utils import BoundedSet
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +35,7 @@ class ChatBridge:
         seen_content: Optional[Set[str]] = None,
         auth_data_dir: Optional[str] = None,
         cron_store: Optional["CronStore"] = None,
+        seen_content_max_size: int = 10_000,
     ):
         self.registry = registry
         self.poll_interval_s = poll_interval_s
@@ -47,7 +49,10 @@ class ChatBridge:
         self._poll_task: Optional[asyncio.Task] = None
         self._stop_event = asyncio.Event()
         self._last_message_time: Optional[str] = last_message_time
-        self._seen_content: Set[str] = seen_content or set()
+        self._seen_content: BoundedSet = BoundedSet(seen_content_max_size)
+        if seen_content:
+            for item in seen_content:
+                self._seen_content.add(item)
 
     async def start(self) -> None:
         if self.service is None:

--- a/g3lobster/chat/email_bridge.py
+++ b/g3lobster/chat/email_bridge.py
@@ -25,6 +25,8 @@ import re
 from pathlib import Path
 from typing import Optional, Set
 
+from g3lobster.utils import BoundedSet
+
 logger = logging.getLogger(__name__)
 
 # Matches the local-part "prefix+agent_id" from a recipient address.
@@ -99,6 +101,7 @@ class EmailBridge:
         poll_interval_s: float = 30.0,
         auth_data_dir: Optional[str] = None,
         service=None,
+        seen_ids_max_size: int = 10_000,
     ) -> None:
         self.registry = registry
         self.base_address = base_address
@@ -108,7 +111,7 @@ class EmailBridge:
 
         self._poll_task: Optional[asyncio.Task] = None
         self._stop_event = asyncio.Event()
-        self._seen_message_ids: Set[str] = set()
+        self._seen_message_ids: BoundedSet = BoundedSet(seen_ids_max_size)
 
     async def start(self) -> None:
         if self.service is None:

--- a/g3lobster/utils.py
+++ b/g3lobster/utils.py
@@ -1,0 +1,36 @@
+"""Shared utility classes for g3lobster."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from typing import Iterator
+
+
+class BoundedSet:
+    """A set with a maximum size that evicts the oldest entries (FIFO) when full.
+
+    Drop-in replacement for ``set`` supporting ``in``, ``add``, and ``len``.
+    Designed to cap memory-resident dedup caches in long-running bridges.
+    """
+
+    def __init__(self, max_size: int = 10_000) -> None:
+        if max_size < 1:
+            raise ValueError("max_size must be >= 1")
+        self._max_size = max_size
+        self._store: OrderedDict[str, None] = OrderedDict()
+
+    def __contains__(self, item: object) -> bool:
+        return item in self._store
+
+    def add(self, item: str) -> None:
+        if item in self._store:
+            return
+        self._store[item] = None
+        if len(self._store) > self._max_size:
+            self._store.popitem(last=False)
+
+    def __len__(self) -> int:
+        return len(self._store)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._store)


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #22.

Replaced unbounded `set[str]` in `ChatBridge._seen_content` and `EmailBridge._seen_message_ids` with a new `BoundedSet` class that enforces a configurable maximum size (default 10,000) with FIFO eviction. This prevents unbounded heap growth in long-running deployments.

## Changes
- `g3lobster/utils.py` — new `BoundedSet` class backed by `OrderedDict` with FIFO eviction
- `g3lobster/chat/bridge.py` — use `BoundedSet` for `_seen_content`; accept `seen_content_max_size` parameter
- `g3lobster/chat/email_bridge.py` — use `BoundedSet` for `_seen_message_ids`; accept `seen_ids_max_size` parameter

## Verification
- `make test` (via `.venv/bin/python3`): 88 passed

Closes #22