### PR TITLE
fix: SubagentRegistry — timeout from task start, add mark_running()

### DIFF
--- a/g3lobster/agents/registry.py
+++ b/g3lobster/agents/registry.py
@@ -238,9 +238,8 @@ class AgentRegistry:
                 return self.subagent_registry.get_run(run.run_id)
             child = self.get_agent(child_agent_id)
 
-        # Mark as running
-        run.status = RunStatus.RUNNING
-        self.subagent_registry._save_to_disk()
+        # Mark as running (records started_at and persists)
+        self.subagent_registry.mark_running(run.run_id)
 
         # Assign task to child agent
         child_task = Task(prompt=task_prompt, session_id=run.session_id, timeout_s=timeout_s)

--- a/g3lobster/agents/subagent_registry.py
+++ b/g3lobster/agents/subagent_registry.py
@@ -34,6 +34,7 @@ class SubagentRun:
     result: Optional[str] = None
     error: Optional[str] = None
     created_at: float = field(default_factory=time.time)
+    started_at: Optional[float] = None
     completed_at: Optional[float] = None
     timeout_s: float = 300.0  # 5 min default
 
@@ -74,6 +75,15 @@ class SubagentRegistry:
         )
         return run
 
+    def mark_running(self, run_id: str) -> None:
+        """Transition a registered run to RUNNING and record the start time."""
+        run = self._runs.get(run_id)
+        if not run:
+            return
+        run.status = RunStatus.RUNNING
+        run.started_at = time.time()
+        self._save_to_disk()
+
     def complete_run(self, run_id: str, result: str) -> None:
         run = self._runs.get(run_id)
         if not run:
@@ -97,7 +107,8 @@ class SubagentRegistry:
         timed_out = []
         now = time.time()
         for run in self._runs.values():
-            if run.status == RunStatus.RUNNING and (now - run.created_at) > run.timeout_s:
+            ref_time = run.started_at if run.started_at is not None else run.created_at
+            if run.status == RunStatus.RUNNING and (now - ref_time) > run.timeout_s:
                 run.status = RunStatus.TIMED_OUT
                 run.error = f"Timed out after {run.timeout_s}s"
                 run.completed_at = now


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #23.

Two bugs fixed: (1) `check_timeouts()` was measuring elapsed time from `created_at` (registration time) instead of when the run actually started executing; (2) `AgentRegistry.delegate_task` was calling the private `_save_to_disk()` directly, violating encapsulation.

## Changes
- `SubagentRun` — added `started_at: Optional[float]` field
- `SubagentRegistry.mark_running()` — new public method that transitions status to RUNNING, records `started_at`, and persists
- `SubagentRegistry.check_timeouts()` — now uses `started_at` as reference (falls back to `created_at` for legacy persisted runs missing the field)
- `AgentRegistry.delegate_task` — replaced `run.status = RUNNING; _save_to_disk()` with `mark_running(run_id)`

## Verification
- `make test`: 88 passed

Closes #23