### PR TITLE
fix: CronManager.reload() guard before start(); clear scheduler on stop()

### DIFF
--- a/g3lobster/cron/manager.py
+++ b/g3lobster/cron/manager.py
@@ -54,11 +54,15 @@ class CronManager:
         if self._scheduler and self._scheduler.running:
             self._scheduler.shutdown(wait=False)
             logger.info("CronManager stopped")
+        self._scheduler = None
 
     def reload(self) -> None:
         """Re-read the store and re-sync all scheduled jobs."""
         scheduler = self._get_scheduler()
         if scheduler is None:
+            return
+        if not scheduler.running:
+            logger.debug("CronManager.reload() called before start() — skipping")
             return
         scheduler.remove_all_jobs()
         self._load_tasks()


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #24.

Two fixes: (1) `reload()` now returns early with a debug log when the scheduler is not running, preventing jobs from being silently added to a stopped scheduler; (2) `stop()` now sets `self._scheduler = None` so subsequent `_get_scheduler()` calls create a fresh instance rather than returning a dead one.

## Changes
- `g3lobster/cron/manager.py` — `stop()`: null out `self._scheduler` after shutdown
- `g3lobster/cron/manager.py` — `reload()`: guard `if not scheduler.running: return`

## Verification
- `make test`: 88 passed

Closes #24