### PR TITLE
feat: per-agent activity metrics endpoint

### DIFF
--- a/g3lobster/api/routes_metrics.py
+++ b/g3lobster/api/routes_metrics.py
@@ -1,0 +1,231 @@
+"""Per-agent activity metrics routes."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, Request
+
+from g3lobster.agents.persona import agent_dir, list_personas, load_persona
+from g3lobster.memory.manager import MemoryManager
+from g3lobster.memory.sessions import SessionStore
+
+router = APIRouter(prefix="/agents", tags=["metrics"])
+
+# Simple TTL cache: {cache_key: (timestamp, data)}
+_cache: Dict[str, tuple] = {}
+_CACHE_TTL_S = 60
+
+
+def _cached(key: str):
+    entry = _cache.get(key)
+    if entry and (time.monotonic() - entry[0]) < _CACHE_TTL_S:
+        return entry[1]
+    return None
+
+
+def _set_cache(key: str, data: Any) -> None:
+    _cache[key] = (time.monotonic(), data)
+
+
+def _memory_manager(request: Request, agent_id: str) -> MemoryManager:
+    registry = request.app.state.registry
+    runtime = registry.get_agent(agent_id)
+    if runtime:
+        return runtime.memory_manager
+
+    cache: dict = request.app.state._stopped_memory_managers
+    cached = cache.get(agent_id)
+    if cached is not None:
+        return cached
+
+    config = request.app.state.config
+    data_dir = str(agent_dir(config.agents.data_dir, agent_id))
+    manager = MemoryManager(
+        data_dir=data_dir,
+        compact_threshold=config.agents.compact_threshold,
+        compact_keep_ratio=config.agents.compact_keep_ratio,
+        compact_chunk_size=config.agents.compact_chunk_size,
+        procedure_min_frequency=config.agents.procedure_min_frequency,
+        memory_max_sections=config.agents.memory_max_sections,
+        gemini_command=config.gemini.command,
+        gemini_args=config.gemini.args,
+        gemini_timeout_s=config.gemini.response_timeout_s,
+        gemini_cwd=config.gemini.workspace_dir,
+    )
+    cache[agent_id] = manager
+    return manager
+
+
+def _compute_metrics(agent_id: str, manager: MemoryManager) -> Dict[str, Any]:
+    """Compute metrics from session JSONL files and memory files."""
+    sessions = manager.sessions
+    session_ids = sessions.list_sessions()
+
+    total_sessions = len(session_ids)
+    today_str = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+    active_today = 0
+
+    total_messages = 0
+    user_messages = 0
+    assistant_messages = 0
+    compaction_events = 0
+
+    response_times: List[float] = []
+
+    for sid in session_ids:
+        path = sessions._session_path(sid)
+        session_active_today = False
+        last_user_ts: Optional[float] = None
+
+        for entry in SessionStore._iter_entries(path):
+            entry_type = entry.get("type")
+            ts_str = entry.get("timestamp", "")
+
+            if entry_type == "compaction":
+                compaction_events += 1
+                continue
+
+            if entry_type != "message":
+                continue
+
+            total_messages += 1
+            role = entry.get("message", {}).get("role", "")
+            if role == "user":
+                user_messages += 1
+            elif role == "assistant":
+                assistant_messages += 1
+
+            # Parse timestamp for today check and response time
+            if ts_str:
+                try:
+                    ts_dt = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+                    ts_epoch = ts_dt.timestamp()
+                except (ValueError, AttributeError):
+                    ts_epoch = None
+                    ts_dt = None
+
+                if ts_dt and ts_dt.strftime("%Y-%m-%d") == today_str:
+                    session_active_today = True
+
+                # Track response times: user -> assistant pairs
+                if role == "user" and ts_epoch is not None:
+                    last_user_ts = ts_epoch
+                elif role == "assistant" and last_user_ts is not None and ts_epoch is not None:
+                    delta = ts_epoch - last_user_ts
+                    if 0 < delta < 600:  # sanity: less than 10 minutes
+                        response_times.append(delta)
+                    last_user_ts = None
+
+        if session_active_today:
+            active_today += 1
+
+    # Response time stats
+    avg_s = 0.0
+    p95_s = 0.0
+    if response_times:
+        response_times.sort()
+        avg_s = round(sum(response_times) / len(response_times), 1)
+        p95_idx = int(len(response_times) * 0.95)
+        p95_s = round(response_times[min(p95_idx, len(response_times) - 1)], 1)
+
+    # Memory stats
+    memory_dir = Path(manager.data_dir) / ".memory"
+    memory_md_path = memory_dir / "MEMORY.md"
+    procedures_path = memory_dir / "PROCEDURES.md"
+    candidates_path = memory_dir / "CANDIDATES.json"
+    daily_dir = memory_dir / "daily"
+
+    memory_md_bytes = memory_md_path.stat().st_size if memory_md_path.exists() else 0
+
+    procedures_count = 0
+    if procedures_path.exists():
+        content = procedures_path.read_text(encoding="utf-8")
+        procedures_count = content.count("## Procedure:")
+
+    candidate_count = 0
+    if candidates_path.exists():
+        try:
+            candidates = json.loads(candidates_path.read_text(encoding="utf-8"))
+            candidate_count = len(candidates) if isinstance(candidates, list) else 0
+        except (json.JSONDecodeError, OSError):
+            pass
+
+    daily_notes = len(list(daily_dir.glob("*.md"))) if daily_dir.exists() else 0
+
+    return {
+        "agent_id": agent_id,
+        "sessions": {
+            "total": total_sessions,
+            "active_today": active_today,
+        },
+        "messages": {
+            "total": total_messages,
+            "user": user_messages,
+            "assistant": assistant_messages,
+            "compaction_events": compaction_events,
+        },
+        "response_time": {
+            "samples": len(response_times),
+            "avg_s": avg_s,
+            "p95_s": p95_s,
+        },
+        "memory": {
+            "memory_md_bytes": memory_md_bytes,
+            "procedures_count": procedures_count,
+            "candidate_count": candidate_count,
+            "daily_notes": daily_notes,
+        },
+    }
+
+
+@router.get("/metrics/summary")
+async def metrics_summary(request: Request) -> dict:
+    cached = _cached("metrics_summary")
+    if cached is not None:
+        return cached
+
+    config = request.app.state.config
+    personas = list_personas(config.agents.data_dir)
+    summary = []
+    for persona in personas:
+        agent_cache_key = f"metrics:{persona.id}"
+        agent_data = _cached(agent_cache_key)
+        if agent_data is None:
+            manager = _memory_manager(request, persona.id)
+            agent_data = _compute_metrics(persona.id, manager)
+            _set_cache(agent_cache_key, agent_data)
+        summary.append({
+            "agent_id": persona.id,
+            "name": persona.name,
+            "emoji": persona.emoji,
+            "sessions_total": agent_data["sessions"]["total"],
+            "messages_total": agent_data["messages"]["total"],
+            "avg_response_s": agent_data["response_time"]["avg_s"],
+        })
+
+    result = {"agents": summary}
+    _set_cache("metrics_summary", result)
+    return result
+
+
+@router.get("/{agent_id}/metrics")
+async def agent_metrics(agent_id: str, request: Request) -> dict:
+    config = request.app.state.config
+    persona = load_persona(config.agents.data_dir, agent_id)
+    if not persona:
+        raise HTTPException(status_code=404, detail="Agent not found")
+
+    cache_key = f"metrics:{agent_id}"
+    cached = _cached(cache_key)
+    if cached is not None:
+        return cached
+
+    manager = _memory_manager(request, agent_id)
+    data = _compute_metrics(agent_id, manager)
+    _set_cache(cache_key, data)
+    return data

--- a/g3lobster/api/server.py
+++ b/g3lobster/api/server.py
@@ -15,6 +15,7 @@ from g3lobster.api.routes_chat_events import router as chat_events_router
 from g3lobster.api.routes_cron import router as cron_router
 from g3lobster.api.routes_delegation import router as delegation_router
 from g3lobster.api.routes_health import router as health_router
+from g3lobster.api.routes_metrics import router as metrics_router
 from g3lobster.api.routes_setup import router as setup_router
 from g3lobster.config import AppConfig
 
@@ -73,6 +74,7 @@ def create_app(
     app.include_router(setup_router)
     app.include_router(chat_events_router)
     app.include_router(delegation_router)
+    app.include_router(metrics_router)
     app.include_router(cron_router)
 
     static_dir = Path(__file__).resolve().parent.parent / "static"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,82 @@
+"""Tests for per-agent activity metrics."""
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from g3lobster.api.routes_metrics import _compute_metrics, _cache
+from g3lobster.memory.manager import MemoryManager
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    _cache.clear()
+    yield
+    _cache.clear()
+
+
+def _make_manager(tmp_path: Path) -> MemoryManager:
+    data_dir = str(tmp_path / "agent-data")
+    return MemoryManager(
+        data_dir=data_dir,
+        compact_threshold=40,
+        compact_keep_ratio=0.25,
+        compact_chunk_size=10,
+        procedure_min_frequency=3,
+        memory_max_sections=50,
+        gemini_command="echo",
+        gemini_args=[],
+        gemini_timeout_s=5.0,
+        gemini_cwd=".",
+    )
+
+
+def test_compute_metrics_empty(tmp_path):
+    manager = _make_manager(tmp_path)
+    result = _compute_metrics("test-agent", manager)
+    assert result["agent_id"] == "test-agent"
+    assert result["sessions"]["total"] == 0
+    assert result["messages"]["total"] == 0
+    assert result["response_time"]["samples"] == 0
+
+
+def test_compute_metrics_with_sessions(tmp_path):
+    manager = _make_manager(tmp_path)
+    now = datetime.now(timezone.utc)
+    ts1 = now.isoformat()
+    ts2 = now.isoformat()
+
+    manager.sessions.append_message("s1", "user", "hello", metadata=None)
+    manager.sessions.append_message("s1", "assistant", "hi there", metadata=None)
+    manager.sessions.append_message("s1", "user", "how are you?", metadata=None)
+    manager.sessions.append_message("s1", "assistant", "good!", metadata=None)
+
+    result = _compute_metrics("test-agent", manager)
+    assert result["sessions"]["total"] == 1
+    assert result["messages"]["total"] == 4
+    assert result["messages"]["user"] == 2
+    assert result["messages"]["assistant"] == 2
+    assert result["sessions"]["active_today"] == 1
+
+
+def test_compute_metrics_memory_stats(tmp_path):
+    manager = _make_manager(tmp_path)
+    memory_dir = Path(manager.data_dir) / ".memory"
+    memory_dir.mkdir(parents=True, exist_ok=True)
+    (memory_dir / "MEMORY.md").write_text("# Memory\nSome notes here", encoding="utf-8")
+    (memory_dir / "PROCEDURES.md").write_text("## Procedure: greet\nSteps\n## Procedure: search\nSteps", encoding="utf-8")
+    (memory_dir / "CANDIDATES.json").write_text('[{"name": "c1"}, {"name": "c2"}]', encoding="utf-8")
+
+    daily_dir = memory_dir / "daily"
+    daily_dir.mkdir(parents=True, exist_ok=True)
+    (daily_dir / "2026-03-01.md").write_text("note", encoding="utf-8")
+    (daily_dir / "2026-03-02.md").write_text("note", encoding="utf-8")
+
+    result = _compute_metrics("test-agent", manager)
+    assert result["memory"]["memory_md_bytes"] > 0
+    assert result["memory"]["procedures_count"] == 2
+    assert result["memory"]["candidate_count"] == 2
+    assert result["memory"]["daily_notes"] == 2


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #28.

Adds `GET /agents/{agent_id}/metrics` and `GET /agents/metrics/summary` endpoints that compute aggregated statistics from session JSONL files and memory files on-demand with 60-second TTL caching.

## Changes
- Added `routes_metrics.py` with two endpoints: per-agent metrics and summary
- Metrics include: session counts, message counts by role, compaction events, response time avg/p95, memory file stats (MEMORY.md size, procedures count, candidates, daily notes)
- 60-second TTL cache to avoid re-scanning JSONL on every request
- Tests covering empty state, session counting, and memory stat computation

## Verification
- `pytest`: 96 tests passing

Closes #28