### PR TITLE
feat: per-thread session isolation and per-user global memory

### DIFF
--- a/g3lobster/api/routes_agents.py
+++ b/g3lobster/api/routes_agents.py
@@ -157,6 +157,19 @@ async def update_global_user_memory(payload: MemoryUpdateRequest, request: Reque
     return {"updated": True}
 
 
+@router.get("/_global/user-memory/{user_id}", response_model=MemoryResponse)
+async def get_per_user_memory(user_id: str, request: Request) -> MemoryResponse:
+    manager = _global_memory_manager(request)
+    return MemoryResponse(content=manager.read_user_memory_for(user_id))
+
+
+@router.put("/_global/user-memory/{user_id}")
+async def update_per_user_memory(user_id: str, payload: MemoryUpdateRequest, request: Request) -> dict:
+    manager = _global_memory_manager(request)
+    manager.write_user_memory_for(user_id, payload.content)
+    return {"updated": True}
+
+
 @router.get("/_global/procedures", response_model=MemoryResponse)
 async def get_global_procedures(request: Request) -> MemoryResponse:
     manager = _global_memory_manager(request)

--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -220,7 +220,8 @@ class ChatBridge:
         persona = runtime.persona
         thread_id = message.get("thread", {}).get("name")
         user_id = sender.get("name") or "unknown"
-        session_id = f"{self.space_id}__{user_id}"
+        thread_id_safe = (thread_id or "no-thread").replace("/", "_")
+        session_id = f"{self.space_id}__{user_id}__{thread_id_safe}"
 
         # Slash-command interception — handle locally without hitting the AI.
         if self.cron_store is not None:

--- a/g3lobster/memory/global_memory.py
+++ b/g3lobster/memory/global_memory.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 import threading
 from pathlib import Path
 from typing import List
@@ -50,6 +51,24 @@ class GlobalMemoryManager:
         """Thread-safe wrapper around ProcedureStore.upsert_procedures."""
         with self._procedures_lock:
             self.procedures.upsert_procedures(procedures)
+
+    def _user_memory_dir(self, user_id: str) -> Path:
+        safe_id = re.sub(r"[^a-zA-Z0-9_.-]", "_", user_id) or "default"
+        return self.memory_dir / "users" / safe_id
+
+    def read_user_memory_for(self, user_id: str) -> str:
+        """Read per-user USER.md, falling back to shared USER.md."""
+        user_dir = self._user_memory_dir(user_id)
+        user_file = user_dir / "USER.md"
+        if user_file.exists():
+            return user_file.read_text(encoding="utf-8")
+        return self.read_user_memory()
+
+    def write_user_memory_for(self, user_id: str, content: str) -> None:
+        """Write per-user USER.md."""
+        user_dir = self._user_memory_dir(user_id)
+        user_dir.mkdir(parents=True, exist_ok=True)
+        (user_dir / "USER.md").write_text(content, encoding="utf-8")
 
     def list_knowledge(self) -> List[str]:
         return sorted(str(path.relative_to(self.knowledge_dir)) for path in self.knowledge_dir.rglob("*") if path.is_file())

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -121,7 +121,7 @@ async def test_chat_bridge_routes_to_named_agent_by_bot_user_id(tmp_path) -> Non
 
 @pytest.mark.asyncio
 async def test_chat_bridge_session_key_is_space_and_user(tmp_path) -> None:
-    """Messages from the same user in different threads share one session key."""
+    """Messages from the same user in different threads get isolated session keys."""
     data_dir = str(tmp_path / "data")
     persona = save_persona(
         data_dir,
@@ -175,11 +175,13 @@ async def test_chat_bridge_session_key_is_space_and_user(tmp_path) -> None:
     await bridge.handle_message(msg2)
 
     assert len(captured_session_ids) == 2
-    assert captured_session_ids[0] == captured_session_ids[1], (
-        "Same user in same space must produce the same session_id regardless of thread"
+    assert captured_session_ids[0] != captured_session_ids[1], (
+        "Different threads must produce different session_ids for per-thread isolation"
     )
     assert "spaces/test" in captured_session_ids[0]
     assert "users/123" in captured_session_ids[0]
+    assert "threads_aaa" in captured_session_ids[0]
+    assert "threads_bbb" in captured_session_ids[1]
 
 
 @pytest.mark.asyncio

--- a/tests/test_session_isolation.py
+++ b/tests/test_session_isolation.py
@@ -1,0 +1,58 @@
+"""Tests for per-thread session isolation and per-user global memory."""
+
+from pathlib import Path
+
+import pytest
+
+from g3lobster.memory.global_memory import GlobalMemoryManager
+
+
+def test_thread_scoped_session_id():
+    """Session ID should include thread_id for isolation."""
+    space_id = "spaces/X"
+    user_id = "users/alice"
+    thread_id = "spaces/X/threads/abc"
+
+    thread_id_safe = (thread_id or "no-thread").replace("/", "_")
+    session_id = f"{space_id}__{user_id}__{thread_id_safe}"
+
+    assert "threads" in session_id
+    assert "alice" in session_id
+
+
+def test_thread_scoped_no_thread():
+    """Without a thread, session_id should use 'no-thread'."""
+    space_id = "spaces/X"
+    user_id = "users/bob"
+    thread_id = None
+
+    thread_id_safe = (thread_id or "no-thread").replace("/", "_")
+    session_id = f"{space_id}__{user_id}__{thread_id_safe}"
+
+    assert "no-thread" in session_id
+
+
+def test_per_user_memory_fallback(tmp_path):
+    """Per-user memory should fall back to shared USER.md."""
+    manager = GlobalMemoryManager(str(tmp_path / "data"))
+    content = manager.read_user_memory_for("unknown-user")
+    assert "# USER" in content  # shared default
+
+
+def test_per_user_memory_write_and_read(tmp_path):
+    """Writing per-user memory should be readable."""
+    manager = GlobalMemoryManager(str(tmp_path / "data"))
+    manager.write_user_memory_for("alice", "# Alice Prefs\nprefers dark mode")
+    result = manager.read_user_memory_for("alice")
+    assert "dark mode" in result
+
+
+def test_per_user_memory_isolation(tmp_path):
+    """Two users should have separate memory."""
+    manager = GlobalMemoryManager(str(tmp_path / "data"))
+    manager.write_user_memory_for("alice", "Alice's memory")
+    manager.write_user_memory_for("bob", "Bob's memory")
+
+    assert "Alice" in manager.read_user_memory_for("alice")
+    assert "Bob" in manager.read_user_memory_for("bob")
+    assert "Alice" not in manager.read_user_memory_for("bob")


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #30.

Adds per-thread session isolation in ChatBridge and per-user global memory namespacing in GlobalMemoryManager.

## Changes
- Session IDs now include thread_id: `{space}__{user}__{thread}` for per-thread context isolation
- Added per-user memory methods on GlobalMemoryManager: `read_user_memory_for(user_id)` / `write_user_memory_for(user_id, content)` with fallback to shared USER.md
- Added API routes `GET/PUT /_global/user-memory/{user_id}` for per-user memory management
- Updated existing test to reflect new per-thread isolation behavior
- Added 5 new tests for session isolation and per-user memory

## Verification
- `pytest`: 104 tests passing

Closes #30