### PR TITLE
feat: QOL updates — MCP skill selector, streaming tool relay, DM allowlist

### DIFF
--- a/g3lobster/agents/persona.py
+++ b/g3lobster/agents/persona.py
@@ -28,6 +28,7 @@ class AgentPersona:
     mcp_servers: List[str] = field(default_factory=lambda: ["*"])
     bot_user_id: Optional[str] = None
     enabled: bool = True
+    dm_allowlist: List[str] = field(default_factory=list)
     created_at: str = field(default_factory=lambda: _utc_now())
     updated_at: str = field(default_factory=lambda: _utc_now())
 
@@ -46,6 +47,7 @@ class AgentPersona:
             self.bot_user_id = str(self.bot_user_id).strip() or None
         else:
             self.bot_user_id = None
+        self.dm_allowlist = [str(item).strip() for item in self.dm_allowlist if str(item).strip()]
 
     def to_agent_json(self) -> Dict[str, object]:
         return {
@@ -56,6 +58,7 @@ class AgentPersona:
             "mcp_servers": list(self.mcp_servers),
             "bot_user_id": self.bot_user_id,
             "enabled": bool(self.enabled),
+            "dm_allowlist": list(self.dm_allowlist),
             "created_at": self.created_at,
             "updated_at": self.updated_at,
         }
@@ -153,6 +156,7 @@ def load_persona(data_dir: str, agent_id: str, *, skip_migration: bool = False) 
         mcp_servers=list(payload.get("mcp_servers") or ["*"]),
         bot_user_id=payload.get("bot_user_id"),
         enabled=bool(payload.get("enabled", True)),
+        dm_allowlist=list(payload.get("dm_allowlist") or []),
         created_at=str(payload.get("created_at") or _utc_now()),
         updated_at=str(payload.get("updated_at") or _utc_now()),
     )
@@ -175,6 +179,7 @@ def save_persona(data_dir: str, persona: AgentPersona) -> AgentPersona:
         mcp_servers=list(persona.mcp_servers),
         bot_user_id=persona.bot_user_id,
         enabled=persona.enabled,
+        dm_allowlist=list(persona.dm_allowlist),
         created_at=(existing.created_at if existing else persona.created_at) or now,
         updated_at=now,
     )

--- a/g3lobster/agents/registry.py
+++ b/g3lobster/agents/registry.py
@@ -67,6 +67,16 @@ class RegisteredAgent:
         finally:
             self._pending_assignments -= 1
 
+    async def assign_stream(self, task):
+        """Assign a task and yield streaming events, serialising with the assign lock."""
+        self._pending_assignments += 1
+        try:
+            async with self._assign_lock:
+                async for event in self.agent.assign_stream(task):
+                    yield event
+        finally:
+            self._pending_assignments -= 1
+
 
 class AgentRegistry:
     """Manages named agents and their per-agent runtime dependencies."""

--- a/g3lobster/api/models.py
+++ b/g3lobster/api/models.py
@@ -14,6 +14,7 @@ class AgentCreateRequest(BaseModel):
     model: str = "gemini"
     mcp_servers: List[str] = Field(default_factory=lambda: ["*"])
     enabled: bool = True
+    dm_allowlist: List[str] = Field(default_factory=list)
 
 
 class AgentUpdateRequest(BaseModel):
@@ -24,6 +25,7 @@ class AgentUpdateRequest(BaseModel):
     mcp_servers: Optional[List[str]] = None
     enabled: Optional[bool] = None
     bot_user_id: Optional[str] = None
+    dm_allowlist: Optional[List[str]] = None
 
 
 class AgentResponse(BaseModel):
@@ -45,6 +47,7 @@ class AgentDetailResponse(AgentResponse):
     soul: str
     created_at: str
     updated_at: str
+    dm_allowlist: List[str] = Field(default_factory=list)
 
 
 class MemoryResponse(BaseModel):

--- a/g3lobster/api/routes_agents.py
+++ b/g3lobster/api/routes_agents.py
@@ -119,6 +119,7 @@ async def create_agent(payload: AgentCreateRequest, request: Request) -> AgentDe
         model=payload.model,
         mcp_servers=payload.mcp_servers,
         enabled=payload.enabled,
+        dm_allowlist=list(payload.dm_allowlist),
     )
     saved = save_persona(config.agents.data_dir, persona)
 
@@ -131,6 +132,7 @@ async def create_agent(payload: AgentCreateRequest, request: Request) -> AgentDe
         "model": saved.model,
         "mcp_servers": list(saved.mcp_servers),
         "bot_user_id": saved.bot_user_id,
+        "dm_allowlist": list(saved.dm_allowlist),
         "state": "stopped",
         "uptime_s": 0,
         "current_task": None,
@@ -142,6 +144,7 @@ async def create_agent(payload: AgentCreateRequest, request: Request) -> AgentDe
         soul=saved.soul,
         created_at=saved.created_at,
         updated_at=saved.updated_at,
+        dm_allowlist=saved.dm_allowlist,
     )
 
 
@@ -193,6 +196,15 @@ async def list_global_knowledge(request: Request) -> KnowledgeListResponse:
     return KnowledgeListResponse(items=manager.list_knowledge())
 
 
+@router.get("/_mcp/servers")
+async def list_mcp_servers(request: Request) -> dict:
+    config = request.app.state.config
+    from g3lobster.mcp.loader import MCPConfigLoader
+    loader = MCPConfigLoader(config_dir=config.mcp.config_dir)
+    names = sorted(loader.load_all().keys())
+    return {"servers": names}
+
+
 @router.get("/{agent_id}", response_model=AgentDetailResponse)
 async def get_agent(agent_id: str, request: Request) -> AgentDetailResponse:
     config = request.app.state.config
@@ -207,6 +219,7 @@ async def get_agent(agent_id: str, request: Request) -> AgentDetailResponse:
         "model": persona.model,
         "mcp_servers": list(persona.mcp_servers),
         "bot_user_id": persona.bot_user_id,
+        "dm_allowlist": list(persona.dm_allowlist),
         "state": "stopped",
         "uptime_s": 0,
         "current_task": None,
@@ -218,6 +231,7 @@ async def get_agent(agent_id: str, request: Request) -> AgentDetailResponse:
         soul=persona.soul,
         created_at=persona.created_at,
         updated_at=persona.updated_at,
+        dm_allowlist=persona.dm_allowlist,
     )
 
 
@@ -246,6 +260,8 @@ async def update_agent(agent_id: str, payload: AgentUpdateRequest, request: Requ
     if "bot_user_id" in updates:
         raw = updates["bot_user_id"]
         persona.bot_user_id = str(raw).strip() if raw else None
+    if "dm_allowlist" in updates:
+        persona.dm_allowlist = [str(item) for item in (updates["dm_allowlist"] or [])]
 
     saved = save_persona(config.agents.data_dir, persona)
 

--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
 from g3lobster.chat.auth import get_authenticated_service
 from g3lobster.chat.commands import handle as handle_command
 from g3lobster.cli.parser import get_content_id
-from g3lobster.tasks.types import Task, TaskStatus
+from g3lobster.tasks.types import Task
 from g3lobster.utils import BoundedSet
 
 logger = logging.getLogger(__name__)
@@ -218,6 +218,17 @@ class ChatBridge:
                 return
 
         persona = runtime.persona
+
+        # Enforce per-agent DM allowlist for direct message spaces
+        space_type = message.get("space", {}).get("spaceType", "")
+        if space_type == "DIRECT_MESSAGE":
+            allowlist = list(getattr(persona, "dm_allowlist", []) or [])
+            if allowlist:
+                sender_name = sender.get("name", "")
+                sender_email = sender.get("email", "")
+                if sender_name not in allowlist and sender_email not in allowlist:
+                    return
+
         thread_id = message.get("thread", {}).get("name")
         user_id = sender.get("name") or "unknown"
         thread_id_safe = (thread_id or "no-thread").replace("/", "_")
@@ -235,20 +246,42 @@ class ChatBridge:
 
         task = Task(prompt=text, session_id=session_id)
 
-        await self.send_message(
+        thinking_msg = await self.send_message(
             f"{persona.emoji} _{persona.name} is thinking..._",
             thread_id=thread_id,
         )
+        thinking_name: Optional[str] = thinking_msg.get("name") if thinking_msg else None
+        active_tools: list = []
 
-        result_task = await runtime.assign(task)
-        if result_task.status == TaskStatus.COMPLETED and result_task.result:
+        from g3lobster.cli.streaming import StreamEventType
+
+        final_result: Optional[str] = None
+        final_error: Optional[str] = None
+
+        async for event in runtime.assign_stream(task):
+            if event.event_type == StreamEventType.TOOL_USE:
+                tool_name = event.data.get("tool", event.data.get("toolName", ""))
+                if tool_name and tool_name not in active_tools:
+                    active_tools.append(tool_name)
+                    if thinking_name:
+                        tools_str = ", ".join(active_tools)
+                        await self.update_message(
+                            thinking_name,
+                            f"{persona.emoji} _{persona.name} is working... [{tools_str}]_",
+                        )
+            elif event.event_type == StreamEventType.RESULT:
+                final_result = event.text
+            elif event.event_type == StreamEventType.ERROR:
+                final_error = event.data.get("error", "unknown error")
+
+        if final_result:
             await self.send_message(
-                f"{persona.emoji} {persona.name}: {result_task.result}",
+                f"{persona.emoji} {persona.name}: {final_result}",
                 thread_id=thread_id,
             )
-        elif result_task.status == TaskStatus.FAILED:
+        elif final_error:
             await self.send_message(
-                f"{persona.emoji} {persona.name}: error: {result_task.error}",
+                f"{persona.emoji} {persona.name}: error: {final_error}",
                 thread_id=thread_id,
             )
         else:
@@ -257,11 +290,24 @@ class ChatBridge:
                 thread_id=thread_id,
             )
 
-    async def send_message(self, text: str, thread_id: Optional[str] = None) -> None:
+    async def send_message(self, text: str, thread_id: Optional[str] = None) -> dict:
         body = {"text": text}
         if thread_id:
             body["thread"] = {"name": thread_id}
 
-        await asyncio.to_thread(
+        result = await asyncio.to_thread(
             self.service.spaces().messages().create(parent=self.space_id, body=body).execute
         )
+        return result or {}
+
+    async def update_message(self, message_name: str, text: str) -> None:
+        body = {"text": text}
+        try:
+            await asyncio.to_thread(
+                self.service.spaces()
+                .messages()
+                .update(name=message_name, updateMask="text", body=body)
+                .execute
+            )
+        except Exception:
+            logger.debug("Failed to update message %s", message_name, exc_info=True)

--- a/g3lobster/cli/process.py
+++ b/g3lobster/cli/process.py
@@ -87,6 +87,71 @@ class GeminiProcess:
 
             return stdout.decode("utf-8", errors="replace").strip()
 
+    async def ask_stream(
+        self, prompt: str, timeout: float = 120.0, session_id: Optional[str] = None
+    ):
+        """Send a prompt and yield StreamEvent objects as they arrive.
+
+        Spawns a fresh subprocess with --output-format stream-json and reads
+        stdout line-by-line, yielding parsed StreamEvent objects.
+        """
+        if not self._ready:
+            raise RuntimeError("GeminiProcess has not been initialised (call spawn first)")
+
+        from g3lobster.cli.streaming import StreamEventType, parse_stream_event
+
+        cmd = [self.command] + self.args + ["--output-format", "stream-json", PROMPT_FLAG, prompt]
+        if self._mcp_server_names and self._mcp_server_names != ["*"]:
+            cmd.extend([ALLOWED_MCP_SERVER_NAMES_FLAG, *self._mcp_server_names])
+
+        env = os.environ.copy()
+        env.update(self.env)
+        if self.agent_id:
+            env["G3LOBSTER_AGENT_ID"] = self.agent_id
+        if session_id:
+            env["G3LOBSTER_SESSION_ID"] = session_id
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            cwd=self.cwd,
+            env=env,
+        )
+        self._active_process = proc
+
+        try:
+            assert proc.stdout is not None
+            deadline = asyncio.get_event_loop().time() + timeout
+            while True:
+                remaining = deadline - asyncio.get_event_loop().time()
+                if remaining <= 0:
+                    proc.kill()
+                    raise asyncio.TimeoutError("Stream read timed out")
+
+                try:
+                    line_bytes = await asyncio.wait_for(
+                        proc.stdout.readline(), timeout=min(remaining, 30.0)
+                    )
+                except asyncio.TimeoutError:
+                    continue
+
+                if not line_bytes:
+                    break
+                line = line_bytes.decode("utf-8", errors="replace").rstrip()
+                if not line:
+                    continue
+                event = parse_stream_event(line)
+                yield event
+                if event.event_type in {StreamEventType.RESULT, StreamEventType.ERROR}:
+                    break
+        finally:
+            self._active_process = None
+            if proc.returncode is None:
+                proc.kill()
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=5.0)
+
     async def kill(self) -> None:
         proc = self._active_process
         if not proc or proc.returncode is not None:

--- a/g3lobster/static/js/agents.js
+++ b/g3lobster/static/js/agents.js
@@ -13,6 +13,7 @@ import {
   linkAgentBot,
   listAgentSessions,
   listAgents,
+  listMcpServers,
   listCronTasks,
   listGlobalKnowledge,
   restartAgent,
@@ -49,6 +50,17 @@ function parseMcpServers(raw) {
     .filter(Boolean);
 }
 
+function parseDmAllowlist(raw) {
+  const value = String(raw || "").trim();
+  if (!value) {
+    return [];
+  }
+  return value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
 function stateClass(state) {
   return String(state || "").toLowerCase();
 }
@@ -71,6 +83,8 @@ export async function render(root, { onSetupChange }) {
   const sessionsCache = {};
   const transcriptCache = {};
   const cronsCache = {};
+
+  let availableMcpServers = null;
 
   let globalUserMemory = "";
   let globalProcedures = "";
@@ -103,6 +117,18 @@ export async function render(root, { onSetupChange }) {
       const payload = await listGlobalKnowledge();
       globalKnowledge = payload.items || [];
     }
+  }
+
+  async function ensureAvailableMcpServers() {
+    if (availableMcpServers === null) {
+      try {
+        const payload = await listMcpServers();
+        availableMcpServers = payload.servers || [];
+      } catch (_err) {
+        availableMcpServers = [];
+      }
+    }
+    return availableMcpServers;
   }
 
   function getActiveAgent(agents) {
@@ -151,7 +177,7 @@ export async function render(root, { onSetupChange }) {
     `;
   }
 
-  function personaTabMarkup(agent, detail) {
+  function personaTabMarkup(agent, detail, mcpServers) {
     return `
       <form class="persona-form" data-agent-id="${escapeHtml(agent.id)}">
         <div class="form-grid">
@@ -169,7 +195,17 @@ export async function render(root, { onSetupChange }) {
           </div>
           <div class="field">
             <label>MCP Servers</label>
-            <input name="mcp_servers" value="${escapeHtml((detail.mcp_servers || ["*"]).join(", "))}" />
+            ${
+              mcpServers && mcpServers.length
+                ? `<div class="mcp-checklist">
+                    ${mcpServers.map((srv) => {
+                      const checked = (detail.mcp_servers || ["*"]).includes("*") || (detail.mcp_servers || []).includes(srv) ? "checked" : "";
+                      return `<label class="mcp-option"><input type="checkbox" name="mcp_server_item" value="${escapeHtml(srv)}" ${checked} /> ${escapeHtml(srv)}</label>`;
+                    }).join("")}
+                  </div>
+                  <label class="mcp-option"><input type="checkbox" name="mcp_server_wildcard" ${(detail.mcp_servers || ["*"]).includes("*") ? "checked" : ""} /> * (all servers)</label>`
+                : `<input name="mcp_servers" value="${escapeHtml((detail.mcp_servers || ["*"]).join(", "))}" />`
+            }
           </div>
         </div>
         <div class="field">
@@ -188,6 +224,10 @@ export async function render(root, { onSetupChange }) {
               <option value="false" ${detail.enabled ? "" : "selected"}>false</option>
             </select>
           </div>
+        </div>
+        <div class="field">
+          <label>DM Allowlist (one sender ID per line)</label>
+          <textarea name="dm_allowlist" placeholder="users/abc123&#10;user@example.com">${escapeHtml((detail.dm_allowlist || []).join("\n"))}</textarea>
         </div>
         <div class="actions">
           <button class="btn btn-primary" type="submit">Save Persona</button>
@@ -334,7 +374,7 @@ export async function render(root, { onSetupChange }) {
     if (activeTab === "crons") {
       return cronsTabMarkup(agent);
     }
-    return personaTabMarkup(agent, detail);
+    return personaTabMarkup(agent, detail, availableMcpServers || []);
   }
 
   async function rerender() {
@@ -360,6 +400,7 @@ export async function render(root, { onSetupChange }) {
         detailCache[activeAgent.id] = detailCache[activeAgent.id] || activeAgent;
       }
     }
+    await ensureAvailableMcpServers();
 
     const bridgeLabel = setup.bridge_running ? "running" : "stopped";
     const bridgeClass = setup.bridge_running ? "ok" : "error";
@@ -644,14 +685,34 @@ export async function render(root, { onSetupChange }) {
 
         const data = new FormData(form);
         try {
+          // Build mcp_servers from checklist (if present) or fallback to text input
+          let mcpServersValue;
+          const wildcardChecked = form.querySelector("input[name='mcp_server_wildcard']");
+          const itemCheckboxes = form.querySelectorAll("input[name='mcp_server_item']:checked");
+          if (wildcardChecked !== null) {
+            // Checklist mode
+            if (wildcardChecked.checked) {
+              mcpServersValue = ["*"];
+            } else {
+              mcpServersValue = Array.from(itemCheckboxes).map((cb) => cb.value).filter(Boolean);
+              if (!mcpServersValue.length) {
+                mcpServersValue = ["*"];
+              }
+            }
+          } else {
+            // Fallback text input mode
+            mcpServersValue = parseMcpServers(data.get("mcp_servers"));
+          }
+
           const payload = {
             name: String(data.get("name") || "").trim(),
             emoji: String(data.get("emoji") || "🤖").trim() || "🤖",
             model: String(data.get("model") || "gemini").trim() || "gemini",
             soul: String(data.get("soul") || ""),
-            mcp_servers: parseMcpServers(data.get("mcp_servers")),
+            mcp_servers: mcpServersValue,
             enabled: String(data.get("enabled") || "true") === "true",
             bot_user_id: String(data.get("bot_user_id") || "").trim() || null,
+            dm_allowlist: parseDmAllowlist(data.get("dm_allowlist")),
           };
           detailCache[agentId] = await updateAgent(agentId, payload);
           setNotice("success", `Updated ${agentId}.`);

--- a/g3lobster/static/js/api.js
+++ b/g3lobster/static/js/api.js
@@ -207,3 +207,7 @@ export function deleteCronTask(agentId, taskId) {
     method: "DELETE",
   });
 }
+
+export function listMcpServers() {
+  return request("/agents/_mcp/servers", { method: "GET" });
+}

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -26,6 +26,9 @@ class FakeMessagesAPI:
         self.created.append({"parent": parent, "body": body})
         return FakeCall({"name": "spaces/test/messages/1"})
 
+    def update(self, name, updateMask, body):
+        return FakeCall({"name": name})
+
 
 class FakeSpacesAPI:
     def __init__(self, messages_api):
@@ -55,6 +58,15 @@ class FakeRuntimeAgent:
         task.status = TaskStatus.COMPLETED
         task.result = "reply"
         return task
+
+    async def assign_stream(self, task):
+        from g3lobster.cli.streaming import StreamEvent, StreamEventType
+
+        result_task = await self.assign(task)
+        yield StreamEvent(
+            event_type=StreamEventType.RESULT,
+            data={"result": result_task.result or ""},
+        )
 
 
 class FakeRegistry:


### PR DESCRIPTION
## Summary

Automated implementation by legion-implement for #44.

Delivers all three quality-of-life features from the investigation plan:

- **MCP Skill Selector**: `GET /agents/_mcp/servers` endpoint returns available server names from `config/mcp/`; persona tab in the Web UI now renders a checkbox list instead of a free-text input, pre-checked based on current `mcp_servers` (wildcard `*` supported as a dedicated checkbox).
- **Streaming Tool Relay**: `GeminiProcess.ask_stream()` added using `--output-format stream-json`; `RegisteredAgent.assign_stream()` delegates to `GeminiAgent.assign_stream()`; `ChatBridge.handle_message()` iterates stream events — on each `tool_use` event it updates the "thinking…" message in-place listing active tools; final reply sent on `RESULT` event.
- **Per-Agent DM Allowlist**: `AgentPersona.dm_allowlist: List[str]` persisted to `agent.json`; wired through API create/update/detail endpoints; `ChatBridge` enforces the allowlist for `DIRECT_MESSAGE` spaces (drops message if sender not in list and list is non-empty); persona tab adds a textarea (one ID per line).

## Changes

- `g3lobster/agents/persona.py` — add `dm_allowlist` field, serialization, deserialization
- `g3lobster/api/models.py` — add `dm_allowlist` to `AgentCreateRequest`, `AgentUpdateRequest`, `AgentDetailResponse`
- `g3lobster/api/routes_agents.py` — wire `dm_allowlist` in create/update/get; add `GET /_mcp/servers` route
- `g3lobster/cli/process.py` — add `GeminiProcess.ask_stream()` (stream-json subprocess, mirrors `TmuxSubagentProcess`)
- `g3lobster/agents/registry.py` — add `RegisteredAgent.assign_stream()` async generator
- `g3lobster/chat/bridge.py` — streaming relay + DM allowlist enforcement + `send_message()` returns dict + `update_message()`
- `g3lobster/static/js/api.js` — add `listMcpServers()`
- `g3lobster/static/js/agents.js` — MCP checklist UI + `dm_allowlist` textarea + form submit wired
- `tests/test_chat.py` — update `FakeRuntimeAgent` / `FakeMessagesAPI` for streaming interface

## Verification

- `python3 -m py_compile $(find g3lobster -name '*.py')`: passing
- `python3 -m pytest -q`: **106 passed, 2 skipped**

Closes #44