### PR TITLE
feat: MCP skills selector, streaming tool calls, per-agent DM allowlist

### DIFF
--- a/g3lobster/agents/persona.py
+++ b/g3lobster/agents/persona.py
@@ -26,6 +26,7 @@ class AgentPersona:
     soul: str = ""
     model: str = "gemini"
     mcp_servers: List[str] = field(default_factory=lambda: ["*"])
+    dm_allowlist: List[str] = field(default_factory=list)
     bot_user_id: Optional[str] = None
     enabled: bool = True
     created_at: str = field(default_factory=lambda: _utc_now())
@@ -42,6 +43,7 @@ class AgentPersona:
         self.soul = self.soul.strip()
         self.model = self.model.strip() or "gemini"
         self.mcp_servers = [str(item).strip() for item in self.mcp_servers if str(item).strip()] or ["*"]
+        self.dm_allowlist = [str(item).strip() for item in self.dm_allowlist if str(item).strip()]
         if self.bot_user_id:
             self.bot_user_id = str(self.bot_user_id).strip() or None
         else:
@@ -54,6 +56,7 @@ class AgentPersona:
             "emoji": self.emoji,
             "model": self.model,
             "mcp_servers": list(self.mcp_servers),
+            "dm_allowlist": list(self.dm_allowlist),
             "bot_user_id": self.bot_user_id,
             "enabled": bool(self.enabled),
             "created_at": self.created_at,
@@ -151,6 +154,7 @@ def load_persona(data_dir: str, agent_id: str, *, skip_migration: bool = False) 
         soul=soul,
         model=str(payload.get("model", "gemini")),
         mcp_servers=list(payload.get("mcp_servers") or ["*"]),
+        dm_allowlist=list(payload.get("dm_allowlist") or []),
         bot_user_id=payload.get("bot_user_id"),
         enabled=bool(payload.get("enabled", True)),
         created_at=str(payload.get("created_at") or _utc_now()),
@@ -173,6 +177,7 @@ def save_persona(data_dir: str, persona: AgentPersona) -> AgentPersona:
         soul=persona.soul,
         model=persona.model,
         mcp_servers=list(persona.mcp_servers),
+        dm_allowlist=list(persona.dm_allowlist),
         bot_user_id=persona.bot_user_id,
         enabled=persona.enabled,
         created_at=(existing.created_at if existing else persona.created_at) or now,

--- a/g3lobster/agents/registry.py
+++ b/g3lobster/agents/registry.py
@@ -59,6 +59,24 @@ class RegisteredAgent:
         finally:
             self._pending_assignments -= 1
 
+    async def assign_stream(self, task):
+        """Assign a task and yield streaming events under the assignment lock."""
+        self._pending_assignments += 1
+        try:
+            async with self._assign_lock:
+                if hasattr(self.agent, "assign_stream"):
+                    async for event in self.agent.assign_stream(task):
+                        yield event
+                else:
+                    result = await self.agent.assign(task)
+                    from g3lobster.cli.streaming import StreamEvent, StreamEventType
+                    yield StreamEvent(
+                        type=StreamEventType.RESULT,
+                        text=result.result or result.error or "",
+                    )
+        finally:
+            self._pending_assignments -= 1
+
 
 class AgentRegistry:
     """Manages named agents and their per-agent runtime dependencies."""
@@ -202,6 +220,7 @@ class AgentRegistry:
                     "bot_user_id": persona.bot_user_id,
                     "model": persona.model,
                     "mcp_servers": runtime.mcp_servers or list(persona.mcp_servers),
+                    "dm_allowlist": list(persona.dm_allowlist),
                     "state": state,
                     "uptime_s": int(now - runtime.started_at),
                     "current_task": runtime.current_task.id if runtime.current_task else None,
@@ -216,6 +235,7 @@ class AgentRegistry:
                     "bot_user_id": persona.bot_user_id,
                     "model": persona.model,
                     "mcp_servers": list(persona.mcp_servers),
+                    "dm_allowlist": list(persona.dm_allowlist),
                     "state": "stopped",
                     "uptime_s": 0,
                     "current_task": None,

--- a/g3lobster/api/models.py
+++ b/g3lobster/api/models.py
@@ -13,6 +13,7 @@ class AgentCreateRequest(BaseModel):
     soul: str = ""
     model: str = "gemini"
     mcp_servers: List[str] = Field(default_factory=lambda: ["*"])
+    dm_allowlist: List[str] = Field(default_factory=list)
     enabled: bool = True
 
 
@@ -22,6 +23,7 @@ class AgentUpdateRequest(BaseModel):
     soul: Optional[str] = None
     model: Optional[str] = None
     mcp_servers: Optional[List[str]] = None
+    dm_allowlist: Optional[List[str]] = None
     enabled: Optional[bool] = None
     bot_user_id: Optional[str] = None
 
@@ -33,6 +35,7 @@ class AgentResponse(BaseModel):
     enabled: bool
     model: str
     mcp_servers: List[str]
+    dm_allowlist: List[str] = Field(default_factory=list)
     bot_user_id: Optional[str] = None
     state: str
     uptime_s: int

--- a/g3lobster/api/routes_agents.py
+++ b/g3lobster/api/routes_agents.py
@@ -30,8 +30,10 @@ from g3lobster.api.models import (
 )
 from g3lobster.memory.global_memory import GlobalMemoryManager
 from g3lobster.memory.manager import MemoryManager
+from g3lobster.mcp.loader import MCPConfigLoader
 
 router = APIRouter(prefix="/agents", tags=["agents"])
+mcp_router = APIRouter(prefix="/mcp", tags=["mcp"])
 
 
 def _to_agent_response(payload: Dict[str, object]) -> AgentResponse:
@@ -117,6 +119,7 @@ async def create_agent(payload: AgentCreateRequest, request: Request) -> AgentDe
         soul=payload.soul,
         model=payload.model,
         mcp_servers=payload.mcp_servers,
+        dm_allowlist=payload.dm_allowlist,
         enabled=payload.enabled,
     )
     saved = save_persona(config.agents.data_dir, persona)
@@ -129,6 +132,7 @@ async def create_agent(payload: AgentCreateRequest, request: Request) -> AgentDe
         "enabled": saved.enabled,
         "model": saved.model,
         "mcp_servers": list(saved.mcp_servers),
+        "dm_allowlist": list(saved.dm_allowlist),
         "bot_user_id": saved.bot_user_id,
         "state": "stopped",
         "uptime_s": 0,
@@ -191,6 +195,7 @@ async def get_agent(agent_id: str, request: Request) -> AgentDetailResponse:
         "enabled": persona.enabled,
         "model": persona.model,
         "mcp_servers": list(persona.mcp_servers),
+        "dm_allowlist": list(persona.dm_allowlist),
         "bot_user_id": persona.bot_user_id,
         "state": "stopped",
         "uptime_s": 0,
@@ -225,6 +230,8 @@ async def update_agent(agent_id: str, payload: AgentUpdateRequest, request: Requ
         persona.model = str(updates["model"])
     if "mcp_servers" in updates:
         persona.mcp_servers = [str(item) for item in (updates["mcp_servers"] or ["*"])]
+    if "dm_allowlist" in updates:
+        persona.dm_allowlist = [str(item) for item in (updates["dm_allowlist"] or [])]
     if "enabled" in updates:
         persona.enabled = bool(updates["enabled"])
     if "bot_user_id" in updates:
@@ -387,3 +394,10 @@ async def test_agent(agent_id: str, payload: TestAgentRequest, request: Request)
     message = f"{persona.emoji} {persona.name} test: {payload.text}"
     await chat_bridge.send_message(message)
     return {"sent": True}
+
+
+@mcp_router.get("/servers", response_model=List[str])
+async def list_mcp_servers(request: Request) -> List[str]:
+    config = request.app.state.config
+    loader = MCPConfigLoader(config_dir=config.mcp.config_dir)
+    return sorted(loader.load_all().keys())

--- a/g3lobster/api/server.py
+++ b/g3lobster/api/server.py
@@ -10,7 +10,7 @@ from typing import Optional
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
 
-from g3lobster.api.routes_agents import router as agents_router
+from g3lobster.api.routes_agents import mcp_router, router as agents_router
 from g3lobster.api.routes_health import router as health_router
 from g3lobster.api.routes_setup import router as setup_router
 from g3lobster.config import AppConfig
@@ -53,6 +53,7 @@ def create_app(
 
     app.include_router(health_router)
     app.include_router(agents_router)
+    app.include_router(mcp_router)
     app.include_router(setup_router)
 
     static_dir = Path(__file__).resolve().parent.parent / "static"

--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional, Set
 
 from g3lobster.chat.auth import get_authenticated_service
 from g3lobster.cli.parser import get_content_id
+from g3lobster.cli.streaming import StreamEventType
 from g3lobster.tasks.types import Task, TaskStatus
 
 logger = logging.getLogger(__name__)
@@ -188,6 +189,23 @@ class ChatBridge:
                 return
 
         persona = runtime.persona
+
+        # Enforce DM allowlist: if the space is a DM and the agent has
+        # a non-empty allowlist, only allow senders whose user name or
+        # email appears in the list.
+        space_type = message.get("space", {}).get("spaceType", "")
+        if persona.dm_allowlist and space_type == "DIRECT_MESSAGE":
+            sender_name = sender.get("name", "")
+            sender_email = sender.get("email", "")
+            allowed = {item.strip() for item in persona.dm_allowlist if item.strip()}
+            if sender_name not in allowed and sender_email not in allowed:
+                logger.info(
+                    "DM from %s blocked by allowlist for agent %s",
+                    sender_name or sender_email,
+                    persona.id,
+                )
+                return
+
         thread_id = message.get("thread", {}).get("name")
         session_id = thread_id or sender.get("name") or "default"
 
@@ -198,22 +216,55 @@ class ChatBridge:
             thread_id=thread_id,
         )
 
-        result_task = await runtime.assign(task)
-        if result_task.status == TaskStatus.COMPLETED and result_task.result:
-            await self.send_message(
-                f"{persona.emoji} {persona.name}: {result_task.result}",
-                thread_id=thread_id,
-            )
-        elif result_task.status == TaskStatus.FAILED:
-            await self.send_message(
-                f"{persona.emoji} {persona.name}: error: {result_task.error}",
-                thread_id=thread_id,
-            )
+        # Use streaming when available to relay tool-use updates to chat.
+        if hasattr(runtime, "assign_stream"):
+            tools_seen: list = []
+            result_text = ""
+            async for event in runtime.assign_stream(task):
+                if event.type == StreamEventType.TOOL_USE and event.tool_name:
+                    tools_seen.append(event.tool_name)
+                    status_line = ", ".join(tools_seen[-5:])
+                    await self.send_message(
+                        f"{persona.emoji} _{persona.name} using: {status_line}_",
+                        thread_id=thread_id,
+                    )
+                elif event.type == StreamEventType.RESULT:
+                    result_text = event.text
+                elif event.type == StreamEventType.ERROR:
+                    result_text = ""
+
+            if task.status == TaskStatus.COMPLETED and (task.result or result_text):
+                await self.send_message(
+                    f"{persona.emoji} {persona.name}: {task.result or result_text}",
+                    thread_id=thread_id,
+                )
+            elif task.status == TaskStatus.FAILED:
+                await self.send_message(
+                    f"{persona.emoji} {persona.name}: error: {task.error}",
+                    thread_id=thread_id,
+                )
+            else:
+                await self.send_message(
+                    f"{persona.emoji} {persona.name}: task canceled",
+                    thread_id=thread_id,
+                )
         else:
-            await self.send_message(
-                f"{persona.emoji} {persona.name}: task canceled",
-                thread_id=thread_id,
-            )
+            result_task = await runtime.assign(task)
+            if result_task.status == TaskStatus.COMPLETED and result_task.result:
+                await self.send_message(
+                    f"{persona.emoji} {persona.name}: {result_task.result}",
+                    thread_id=thread_id,
+                )
+            elif result_task.status == TaskStatus.FAILED:
+                await self.send_message(
+                    f"{persona.emoji} {persona.name}: error: {result_task.error}",
+                    thread_id=thread_id,
+                )
+            else:
+                await self.send_message(
+                    f"{persona.emoji} {persona.name}: task canceled",
+                    thread_id=thread_id,
+                )
 
     async def send_message(self, text: str, thread_id: Optional[str] = None) -> None:
         body = {"text": text}

--- a/g3lobster/cli/process.py
+++ b/g3lobster/cli/process.py
@@ -5,10 +5,14 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import os
-from typing import Dict, Iterable, List, Optional
+from typing import AsyncIterator, Dict, Iterable, List, Optional
+
+from g3lobster.cli.streaming import StreamEvent, stream_events
 
 
 ALLOWED_MCP_SERVER_NAMES_FLAG = "--allowed-mcp-server-names"
+STREAM_OUTPUT_FLAG = "--output-format"
+STREAM_OUTPUT_VALUE = "stream-json"
 PROMPT_FLAG = "-p"
 
 
@@ -78,6 +82,52 @@ class GeminiProcess:
                 )
 
             return stdout.decode("utf-8", errors="replace").strip()
+
+    async def ask_stream(self, prompt: str, timeout: float = 120.0) -> AsyncIterator[StreamEvent]:
+        """Spawn a Gemini CLI process with stream-json output and yield events."""
+        if not self._ready:
+            raise RuntimeError("GeminiProcess has not been initialised (call spawn first)")
+
+        async with self._lock:
+            cmd = [self.command] + self.args + [
+                STREAM_OUTPUT_FLAG, STREAM_OUTPUT_VALUE,
+                PROMPT_FLAG, prompt,
+            ]
+            if self._mcp_server_names and self._mcp_server_names != ["*"]:
+                cmd.extend([ALLOWED_MCP_SERVER_NAMES_FLAG, *self._mcp_server_names])
+
+            env = os.environ.copy()
+            env.update(self.env)
+
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                cwd=self.cwd,
+                env=env,
+            )
+            self._active_process = proc
+
+            try:
+                async def _read_lines() -> AsyncIterator[bytes]:
+                    assert proc.stdout is not None
+                    while True:
+                        line = await asyncio.wait_for(proc.stdout.readline(), timeout=timeout)
+                        if not line:
+                            break
+                        yield line
+
+                async for event in stream_events(_read_lines()):
+                    yield event
+
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                proc.kill()
+                with contextlib.suppress(Exception):
+                    await asyncio.wait_for(proc.wait(), timeout=5.0)
+                raise
+            finally:
+                self._active_process = None
 
     async def kill(self) -> None:
         proc = self._active_process

--- a/g3lobster/cli/streaming.py
+++ b/g3lobster/cli/streaming.py
@@ -1,0 +1,109 @@
+"""Streaming event types and parser for Gemini CLI stream-json output."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, AsyncIterator, Dict, Optional
+
+
+class StreamEventType(str, Enum):
+    TEXT_DELTA = "text_delta"
+    TOOL_USE = "tool_use"
+    TURN_END = "turn_end"
+    RESULT = "result"
+    ERROR = "error"
+
+
+@dataclass
+class StreamEvent:
+    """A single event parsed from Gemini CLI stream-json output."""
+
+    type: StreamEventType
+    text: str = ""
+    tool_name: str = ""
+    data: Dict[str, Any] = field(default_factory=dict)
+
+
+def parse_stream_event(line: str) -> Optional[StreamEvent]:
+    """Parse a single line of stream-json output into a StreamEvent.
+
+    Returns None for lines that are not valid JSON or not recognized events.
+    """
+    stripped = line.strip()
+    if not stripped:
+        return None
+
+    try:
+        obj = json.loads(stripped)
+    except json.JSONDecodeError:
+        return None
+
+    if not isinstance(obj, dict):
+        return None
+
+    # Gemini CLI stream-json emits objects with varying shapes.
+    # Detect event type from the object structure.
+
+    # Tool use events
+    if "toolCall" in obj or "tool_call" in obj:
+        tool_call = obj.get("toolCall") or obj.get("tool_call") or {}
+        tool_name = tool_call.get("name") or tool_call.get("tool", "")
+        return StreamEvent(
+            type=StreamEventType.TOOL_USE,
+            tool_name=str(tool_name),
+            data=obj,
+        )
+
+    # Text delta events
+    if "text" in obj and isinstance(obj["text"], str):
+        return StreamEvent(
+            type=StreamEventType.TEXT_DELTA,
+            text=obj["text"],
+            data=obj,
+        )
+
+    # Turn completion / result
+    if "turnComplete" in obj or "turn_complete" in obj:
+        return StreamEvent(type=StreamEventType.TURN_END, data=obj)
+
+    if "result" in obj:
+        result_text = obj.get("result", "")
+        if isinstance(result_text, dict):
+            result_text = result_text.get("text", "")
+        return StreamEvent(
+            type=StreamEventType.RESULT,
+            text=str(result_text),
+            data=obj,
+        )
+
+    # Error events
+    if "error" in obj:
+        return StreamEvent(
+            type=StreamEventType.ERROR,
+            text=str(obj["error"]),
+            data=obj,
+        )
+
+    # Unrecognized JSON line — treat as text delta if it has content
+    return None
+
+
+async def stream_events(lines: AsyncIterator[bytes]) -> AsyncIterator[StreamEvent]:
+    """Convert an async iterator of raw stdout lines into StreamEvents."""
+    full_text_parts = []
+    async for raw_line in lines:
+        line = raw_line.decode("utf-8", errors="replace")
+        event = parse_stream_event(line)
+        if event is not None:
+            if event.type == StreamEventType.TEXT_DELTA:
+                full_text_parts.append(event.text)
+            yield event
+
+    # If no RESULT event was emitted, yield the accumulated text as result.
+    if full_text_parts:
+        yield StreamEvent(
+            type=StreamEventType.RESULT,
+            text="".join(full_text_parts),
+        )

--- a/g3lobster/pool/agent.py
+++ b/g3lobster/pool/agent.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import time
-from typing import Callable, List, Optional
+from typing import AsyncIterator, Callable, List, Optional
 
 from g3lobster.cli.parser import clean_text, strip_reasoning
+from g3lobster.cli.streaming import StreamEvent, StreamEventType
 from g3lobster.memory.context import ContextBuilder
 from g3lobster.memory.manager import MemoryManager
 from g3lobster.mcp.manager import MCPManager
@@ -93,3 +94,58 @@ class GeminiAgent:
                 self.state = AgentState.DEAD
 
         return task
+
+    async def assign_stream(self, task: Task) -> AsyncIterator[StreamEvent]:
+        """Assign a task and yield streaming events.
+
+        Falls back to ``assign()`` if the process does not support streaming,
+        emitting a single RESULT event.
+        """
+        if not hasattr(self.process, "ask_stream"):
+            result_task = await self.assign(task)
+            yield StreamEvent(
+                type=StreamEventType.RESULT,
+                text=result_task.result or result_task.error or "",
+            )
+            return
+
+        if self.state not in {AgentState.IDLE, AgentState.BUSY}:
+            raise RuntimeError(f"Agent {self.id} is not ready")
+
+        self.current_task = task
+        self.busy_since = time.time()
+        self.state = AgentState.BUSY
+
+        task.status = TaskStatus.RUNNING
+        task.agent_id = self.id
+        task.started_at = time.time()
+        task.add_event("started", {"agent_id": self.id})
+
+        try:
+            prompt = self.context_builder.build(task.session_id, task.prompt)
+            self.memory_manager.append_message(task.session_id, "user", task.prompt, {"task_id": task.id})
+            result_text = ""
+            async for event in self.process.ask_stream(prompt, timeout=task.timeout_s):
+                yield event
+                if event.type == StreamEventType.RESULT:
+                    result_text = event.text
+
+            parsed = strip_reasoning(clean_text(result_text))
+            task.result = parsed
+            task.status = TaskStatus.COMPLETED
+            task.completed_at = time.time()
+            task.add_event("completed", {"chars": len(parsed or "")})
+            self.memory_manager.append_message(task.session_id, "assistant", parsed, {"task_id": task.id})
+        except Exception as exc:
+            task.error = str(exc)
+            task.status = TaskStatus.FAILED
+            task.completed_at = time.time()
+            task.add_event("failed", {"error": task.error})
+            yield StreamEvent(type=StreamEventType.ERROR, text=str(exc))
+        finally:
+            self.current_task = None
+            self.busy_since = None
+            if self.is_alive():
+                self.state = AgentState.IDLE
+            else:
+                self.state = AgentState.DEAD

--- a/g3lobster/static/js/agents.js
+++ b/g3lobster/static/js/agents.js
@@ -12,6 +12,7 @@ import {
   listAgentSessions,
   listAgents,
   listGlobalKnowledge,
+  listMcpServers,
   restartAgent,
   startAgent,
   startBridge,
@@ -45,6 +46,42 @@ function parseMcpServers(raw) {
     .filter(Boolean);
 }
 
+function parseDmAllowlist(raw) {
+  const value = String(raw || "").trim();
+  if (!value) {
+    return [];
+  }
+  return value
+    .split("\n")
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function mcpChecklistMarkup(available, selected) {
+  const selectedSet = new Set(selected || ["*"]);
+  const useAll = selectedSet.has("*");
+  if (!available.length) {
+    return `<input name="mcp_servers" value="${escapeHtml((selected || ["*"]).join(", "))}" />`;
+  }
+  const allChecked = useAll ? "checked" : "";
+  let html = `<label class="mcp-check"><input type="checkbox" name="mcp_all" value="*" ${allChecked} /> * (all servers)</label>`;
+  for (const name of available) {
+    const checked = useAll || selectedSet.has(name) ? "checked" : "";
+    html += `<label class="mcp-check"><input type="checkbox" name="mcp_server" value="${escapeHtml(name)}" ${checked} /> ${escapeHtml(name)}</label>`;
+  }
+  return `<div class="mcp-checklist">${html}</div>`;
+}
+
+function collectMcpServers(container) {
+  const allBox = container.querySelector('input[name="mcp_all"]');
+  if (allBox && allBox.checked) {
+    return ["*"];
+  }
+  const boxes = container.querySelectorAll('input[name="mcp_server"]:checked');
+  const names = Array.from(boxes).map((el) => el.value);
+  return names.length ? names : ["*"];
+}
+
 function stateClass(state) {
   return String(state || "").toLowerCase();
 }
@@ -70,6 +107,7 @@ export async function render(root, { onSetupChange }) {
   let globalUserMemory = "";
   let globalProcedures = "";
   let globalKnowledge = [];
+  let availableMcpServers = [];
 
   function setNotice(tone, text) {
     notice = { tone, text };
@@ -164,7 +202,7 @@ export async function render(root, { onSetupChange }) {
           </div>
           <div class="field">
             <label>MCP Servers</label>
-            <input name="mcp_servers" value="${escapeHtml((detail.mcp_servers || ["*"]).join(", "))}" />
+            ${mcpChecklistMarkup(availableMcpServers, detail.mcp_servers)}
           </div>
         </div>
         <div class="field">
@@ -183,6 +221,10 @@ export async function render(root, { onSetupChange }) {
               <option value="false" ${detail.enabled ? "" : "selected"}>false</option>
             </select>
           </div>
+        </div>
+        <div class="field">
+          <label>DM Allowlist (one user ID per line, empty = allow all)</label>
+          <textarea name="dm_allowlist" rows="3">${escapeHtml((detail.dm_allowlist || []).join("\n"))}</textarea>
         </div>
         <div class="actions">
           <button class="btn btn-primary" type="submit">Save Persona</button>
@@ -313,7 +355,7 @@ export async function render(root, { onSetupChange }) {
             </div>
             <div class="field">
               <label>MCP Servers</label>
-              <input name="mcp_servers" value="*" />
+              ${mcpChecklistMarkup(availableMcpServers, ["*"])}
             </div>
             <div class="field" style="grid-column: 1 / -1;">
               <label>SOUL.md</label>
@@ -410,7 +452,7 @@ export async function render(root, { onSetupChange }) {
           name,
           emoji: String(data.get("emoji") || "🤖").trim() || "🤖",
           model: String(data.get("model") || "gemini").trim() || "gemini",
-          mcp_servers: parseMcpServers(data.get("mcp_servers")),
+          mcp_servers: collectMcpServers(form),
           soul: String(data.get("soul") || ""),
         });
         activeAgentId = created.id;
@@ -548,7 +590,8 @@ export async function render(root, { onSetupChange }) {
             emoji: String(data.get("emoji") || "🤖").trim() || "🤖",
             model: String(data.get("model") || "gemini").trim() || "gemini",
             soul: String(data.get("soul") || ""),
-            mcp_servers: parseMcpServers(data.get("mcp_servers")),
+            mcp_servers: collectMcpServers(form),
+            dm_allowlist: parseDmAllowlist(data.get("dm_allowlist")),
             enabled: String(data.get("enabled") || "true") === "true",
             bot_user_id: String(data.get("bot_user_id") || "").trim() || null,
           };
@@ -575,6 +618,12 @@ export async function render(root, { onSetupChange }) {
     await ensureGlobalMemory();
   } catch (_err) {
     // Keep UI usable even if global files are not available yet.
+  }
+
+  try {
+    availableMcpServers = await listMcpServers();
+  } catch (_err) {
+    availableMcpServers = [];
   }
 
   await rerender();

--- a/g3lobster/static/js/api.js
+++ b/g3lobster/static/js/api.js
@@ -183,3 +183,7 @@ export function testAgent(agentId, text = "ping") {
     body: JSON.stringify({ text }),
   });
 }
+
+export function listMcpServers() {
+  return request("/mcp/servers", { method: "GET" });
+}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -386,3 +386,64 @@ def test_setup_routes_bridge_lifecycle(monkeypatch, tmp_path):
     assert saved["chat"]["enabled"] is False
     assert saved["chat"]["space_id"] == "spaces/new"
     assert saved["chat"]["space_name"] == "Ops"
+
+
+def test_mcp_servers_endpoint(tmp_path):
+    app, _bridge_instances, _config_path = _build_test_app(tmp_path)
+
+    # Create an MCP config directory with a server definition
+    mcp_dir = tmp_path / "config" / "mcp"
+    mcp_dir.mkdir(parents=True)
+    (mcp_dir / "gmail.yaml").write_text(
+        "name: gmail\nenabled: true\ntransport:\n  type: sse\n  url: https://example.test\n",
+        encoding="utf-8",
+    )
+    (mcp_dir / "calendar.yaml").write_text(
+        "name: calendar\nenabled: true\ntransport:\n  type: sse\n  url: https://example.test\n",
+        encoding="utf-8",
+    )
+
+    # Point the app config at our test mcp dir
+    app.state.config.mcp.config_dir = str(mcp_dir)
+
+    with TestClient(app) as client:
+        resp = client.get("/mcp/servers")
+        assert resp.status_code == 200
+        servers = resp.json()
+        assert "gmail" in servers
+        assert "calendar" in servers
+        assert servers == sorted(servers)
+
+
+def test_dm_allowlist_persisted_via_api(tmp_path):
+    app, _bridge_instances, _config_path = _build_test_app(tmp_path)
+
+    with TestClient(app) as client:
+        create = client.post(
+            "/agents",
+            json={
+                "name": "Iris",
+                "emoji": "🧭",
+                "soul": "",
+                "model": "gemini",
+                "mcp_servers": ["*"],
+                "dm_allowlist": ["users/a", "users/b"],
+            },
+        )
+        assert create.status_code == 200
+        agent_id = create.json()["id"]
+        assert create.json()["dm_allowlist"] == ["users/a", "users/b"]
+
+        detail = client.get(f"/agents/{agent_id}")
+        assert detail.status_code == 200
+        assert detail.json()["dm_allowlist"] == ["users/a", "users/b"]
+
+        updated = client.put(
+            f"/agents/{agent_id}",
+            json={"dm_allowlist": ["users/c"]},
+        )
+        assert updated.status_code == 200
+        assert updated.json()["dm_allowlist"] == ["users/c"]
+
+        detail2 = client.get(f"/agents/{agent_id}")
+        assert detail2.json()["dm_allowlist"] == ["users/c"]

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -160,3 +160,144 @@ async def test_chat_bridge_ignores_unlinked_mentions(tmp_path) -> None:
     await bridge.handle_message(message)
 
     assert service.messages_api.created == []
+
+
+@pytest.mark.asyncio
+async def test_chat_bridge_dm_allowlist_blocks_unlisted_sender(tmp_path) -> None:
+    """DM from a sender not in the allowlist is silently dropped."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="🦀",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            dm_allowlist=["users/allowed-1"],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+    )
+
+    message = {
+        "text": "Hello there",
+        "sender": {"type": "HUMAN", "name": "users/blocked-user"},
+        "space": {"spaceType": "DIRECT_MESSAGE"},
+        "thread": {"name": "spaces/test/threads/abc"},
+        "annotations": [
+            {
+                "type": "USER_MENTION",
+                "userMention": {"user": {"type": "BOT", "name": "users/999"}},
+            }
+        ],
+    }
+
+    await bridge.handle_message(message)
+
+    # Blocked — no messages sent
+    assert service.messages_api.created == []
+
+
+@pytest.mark.asyncio
+async def test_chat_bridge_dm_allowlist_permits_listed_sender(tmp_path) -> None:
+    """DM from a sender in the allowlist is processed normally."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="🦀",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            dm_allowlist=["users/allowed-1"],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+    )
+
+    message = {
+        "text": "Hello there",
+        "sender": {"type": "HUMAN", "name": "users/allowed-1"},
+        "space": {"spaceType": "DIRECT_MESSAGE"},
+        "thread": {"name": "spaces/test/threads/abc"},
+        "annotations": [
+            {
+                "type": "USER_MENTION",
+                "userMention": {"user": {"type": "BOT", "name": "users/999"}},
+            }
+        ],
+    }
+
+    await bridge.handle_message(message)
+
+    assert len(service.messages_api.created) == 2
+    assert "thinking" in service.messages_api.created[0]["body"]["text"]
+    assert "reply" in service.messages_api.created[1]["body"]["text"]
+
+
+@pytest.mark.asyncio
+async def test_chat_bridge_empty_dm_allowlist_allows_all(tmp_path) -> None:
+    """Empty allowlist means all senders are allowed (default)."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="🦀",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            dm_allowlist=[],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+    )
+
+    message = {
+        "text": "Hello there",
+        "sender": {"type": "HUMAN", "name": "users/anyone"},
+        "space": {"spaceType": "DIRECT_MESSAGE"},
+        "thread": {"name": "spaces/test/threads/abc"},
+        "annotations": [
+            {
+                "type": "USER_MENTION",
+                "userMention": {"user": {"type": "BOT", "name": "users/999"}},
+            }
+        ],
+    }
+
+    await bridge.handle_message(message)
+
+    assert len(service.messages_api.created) == 2

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,152 @@
+"""Tests for streaming event parser and GeminiProcess.ask_stream."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from g3lobster.cli.streaming import StreamEvent, StreamEventType, parse_stream_event, stream_events
+
+
+def test_parse_tool_use_event() -> None:
+    line = json.dumps({"toolCall": {"name": "search_gmail"}})
+    event = parse_stream_event(line)
+    assert event is not None
+    assert event.type == StreamEventType.TOOL_USE
+    assert event.tool_name == "search_gmail"
+
+
+def test_parse_text_delta_event() -> None:
+    line = json.dumps({"text": "Hello world"})
+    event = parse_stream_event(line)
+    assert event is not None
+    assert event.type == StreamEventType.TEXT_DELTA
+    assert event.text == "Hello world"
+
+
+def test_parse_result_event() -> None:
+    line = json.dumps({"result": "final answer"})
+    event = parse_stream_event(line)
+    assert event is not None
+    assert event.type == StreamEventType.RESULT
+    assert event.text == "final answer"
+
+
+def test_parse_error_event() -> None:
+    line = json.dumps({"error": "something broke"})
+    event = parse_stream_event(line)
+    assert event is not None
+    assert event.type == StreamEventType.ERROR
+    assert event.text == "something broke"
+
+
+def test_parse_turn_end_event() -> None:
+    line = json.dumps({"turnComplete": True})
+    event = parse_stream_event(line)
+    assert event is not None
+    assert event.type == StreamEventType.TURN_END
+
+
+def test_parse_empty_line_returns_none() -> None:
+    assert parse_stream_event("") is None
+    assert parse_stream_event("  ") is None
+
+
+def test_parse_invalid_json_returns_none() -> None:
+    assert parse_stream_event("not json") is None
+
+
+def test_parse_non_dict_json_returns_none() -> None:
+    assert parse_stream_event("[1,2,3]") is None
+
+
+@pytest.mark.asyncio
+async def test_stream_events_yields_events() -> None:
+    lines = [
+        json.dumps({"toolCall": {"name": "gmail_send"}}).encode() + b"\n",
+        json.dumps({"text": "Sending email..."}).encode() + b"\n",
+        json.dumps({"result": "Email sent"}).encode() + b"\n",
+    ]
+
+    async def line_iter():
+        for line in lines:
+            yield line
+
+    events = []
+    async for event in stream_events(line_iter()):
+        events.append(event)
+
+    types = [e.type for e in events]
+    assert StreamEventType.TOOL_USE in types
+    assert StreamEventType.TEXT_DELTA in types
+    assert StreamEventType.RESULT in types
+
+
+@pytest.mark.asyncio
+async def test_stream_events_emits_result_from_accumulated_text() -> None:
+    """When no explicit RESULT event is emitted, accumulated text becomes the result."""
+    lines = [
+        json.dumps({"text": "part1 "}).encode() + b"\n",
+        json.dumps({"text": "part2"}).encode() + b"\n",
+    ]
+
+    async def line_iter():
+        for line in lines:
+            yield line
+
+    events = []
+    async for event in stream_events(line_iter()):
+        events.append(event)
+
+    # Should have 2 text deltas + 1 accumulated result
+    result_events = [e for e in events if e.type == StreamEventType.RESULT]
+    assert len(result_events) == 1
+    assert result_events[0].text == "part1 part2"
+
+
+@pytest.mark.asyncio
+async def test_ask_stream_includes_output_format_flag(monkeypatch) -> None:
+    """ask_stream passes --output-format stream-json to the subprocess."""
+    from g3lobster.cli.process import GeminiProcess
+
+    captured = {}
+
+    class DummyProcess:
+        returncode = 0
+
+        def __init__(self):
+            self.stdout = None
+            self.stderr = None
+
+        async def wait(self):
+            pass
+
+    async def fake_exec(*cmd, **kwargs):
+        captured["cmd"] = list(cmd)
+
+        proc = DummyProcess()
+
+        class FakeStdout:
+            async def readline(self):
+                return b""
+
+        proc.stdout = FakeStdout()
+        proc.stderr = asyncio.subprocess.PIPE
+        proc.returncode = 0
+        return proc
+
+    monkeypatch.setattr(asyncio, "create_subprocess_exec", fake_exec)
+
+    proc = GeminiProcess(command="gemini", args=["-y"])
+    await proc.spawn(mcp_server_names=["gmail"])
+
+    events = []
+    async for event in proc.ask_stream("test prompt", timeout=5.0):
+        events.append(event)
+
+    assert "--output-format" in captured["cmd"]
+    assert "stream-json" in captured["cmd"]
+    assert "-p" in captured["cmd"]
+    assert "test prompt" in captured["cmd"]


### PR DESCRIPTION
## Summary

Implements all three QOL features from #44:

- **MCP Skills Selector**: New `GET /mcp/servers` endpoint returns available server names from `config/mcp/`. The persona form now renders a checkbox checklist (with "all" toggle) instead of a free-text input for MCP server selection.
- **Streaming Tool Calls to Chat**: New `streaming.py` module with `StreamEvent` types and JSON line parser. `GeminiProcess.ask_stream()` spawns with `--output-format stream-json` and yields events. `ChatBridge.handle_message()` relays tool-use events to Google Chat threads in real-time (e.g. "_Luna using: search_gmail, send_email_").
- **Per-Agent DM Allowlist**: `AgentPersona.dm_allowlist` field persisted in `agent.json`. API create/update/detail endpoints include `dm_allowlist`. `ChatBridge` enforces the allowlist for `DIRECT_MESSAGE` space types — empty list means allow all. Web UI persona tab has a textarea for managing the list.

Closes #44

## Test plan

- [x] All 61 tests pass (45 existing + 16 new)
- [x] `test_dm_allowlist_persisted_via_api` — create/update/get roundtrip
- [x] `test_chat_bridge_dm_allowlist_blocks_unlisted_sender` — DM blocked when sender not in list
- [x] `test_chat_bridge_dm_allowlist_permits_listed_sender` — DM allowed when sender in list
- [x] `test_chat_bridge_empty_dm_allowlist_allows_all` — empty list = allow all
- [x] `test_mcp_servers_endpoint` — GET /mcp/servers returns sorted list
- [x] `test_parse_tool_use_event`, `test_parse_text_delta_event`, etc. — streaming parser
- [x] `test_ask_stream_includes_output_format_flag` — verify CLI flags
- [x] `test_stream_events_emits_result_from_accumulated_text` — fallback result

🤖 Generated with [Claude Code](https://claude.com/claude-code)