### PR TITLE
feat: structured handoff context for agent delegation

### DIFF
--- a/g3lobster/agents/registry.py
+++ b/g3lobster/agents/registry.py
@@ -15,6 +15,7 @@ from g3lobster.agents.subagent_registry import SubagentRegistry, SubagentRun
 from g3lobster.alerts import AlertManager, make_event
 from g3lobster.memory.context import ContextBuilder
 from g3lobster.memory.global_memory import GlobalMemoryManager
+from g3lobster.memory.handoff import HandoffBuilder
 from g3lobster.memory.manager import MemoryManager
 from g3lobster.pool.health import HealthInspector
 from g3lobster.pool.types import AgentState
@@ -480,8 +481,11 @@ class AgentRegistry:
         # Mark as running (records started_at and persists)
         self.subagent_registry.mark_running(run.run_id)
 
+        # Enrich task prompt with parent's context
+        enriched_prompt = self._build_handoff(parent_agent_id, task_prompt)
+
         # Assign task to child agent
-        child_task = Task(prompt=task_prompt, session_id=run.session_id, timeout_s=timeout_s)
+        child_task = Task(prompt=enriched_prompt, session_id=run.session_id, timeout_s=timeout_s)
         result_task = await child.assign(child_task)
 
         # Record result
@@ -526,7 +530,10 @@ class AgentRegistry:
 
         self.subagent_registry.mark_running(run.run_id)
 
-        child_task = Task(prompt=task_prompt, session_id=run.session_id, timeout_s=timeout_s)
+        # Enrich task prompt with parent's context
+        enriched_prompt = self._build_handoff(parent_agent_id, task_prompt)
+
+        child_task = Task(prompt=enriched_prompt, session_id=run.session_id, timeout_s=timeout_s)
 
         collected_text = []
         try:
@@ -544,6 +551,19 @@ class AgentRegistry:
         except Exception as exc:
             self.subagent_registry.fail_run(run.run_id, str(exc))
             raise
+
+    def _build_handoff(self, parent_agent_id: str, task_prompt: str) -> str:
+        """Enrich a delegation prompt with the parent agent's context."""
+        parent = self._agents.get(parent_agent_id)
+        if not parent:
+            return task_prompt
+        builder = HandoffBuilder()
+        return builder.build(
+            task_prompt=task_prompt,
+            parent_memory=parent.memory_manager,
+            global_memory=self.global_memory_manager,
+            parent_persona_name=parent.persona.name,
+        )
 
     @staticmethod
     def _soul_summary(soul: str) -> str:

--- a/g3lobster/memory/handoff.py
+++ b/g3lobster/memory/handoff.py
@@ -1,0 +1,201 @@
+"""Structured handoff builder for cross-agent delegation.
+
+Enriches raw task prompts with parent agent context (memory excerpts,
+matching procedures, user preferences) before passing to child agents.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from g3lobster.memory.global_memory import GlobalMemoryManager
+from g3lobster.memory.manager import MemoryManager
+
+logger = logging.getLogger(__name__)
+
+
+class HandoffBuilder:
+    """Builds budget-aware enriched prompts for delegation handoffs.
+
+    Composes a structured prompt with sections for parent context,
+    relevant procedures, and user preferences — without exceeding
+    a configurable character budget for the handoff context.
+    """
+
+    def __init__(
+        self,
+        max_context_chars: int = 2000,
+        procedure_limit: int = 3,
+    ):
+        self.max_context_chars = max(100, int(max_context_chars))
+        self.procedure_limit = max(1, int(procedure_limit))
+
+    def build(
+        self,
+        task_prompt: str,
+        parent_memory: MemoryManager,
+        global_memory: Optional[GlobalMemoryManager] = None,
+        parent_persona_name: str = "",
+    ) -> str:
+        """Return an enriched prompt combining parent context with the task.
+
+        If the parent has no relevant context to share, returns the raw
+        task_prompt unchanged.
+        """
+        sections: list[str] = []
+        budget_remaining = self.max_context_chars
+
+        # 1. Parent memory excerpts (query-matched via section relevance)
+        memory_excerpt = self._extract_memory_excerpt(
+            parent_memory, task_prompt, budget_remaining
+        )
+        if memory_excerpt:
+            sections.append(f"## Parent Memory Excerpts\n{memory_excerpt}")
+            budget_remaining -= len(memory_excerpt)
+
+        # 2. Matching procedures from parent
+        procedures_text = self._extract_procedures(
+            parent_memory, task_prompt, global_memory, budget_remaining
+        )
+        if procedures_text:
+            sections.append(f"## Suggested Procedures\n{procedures_text}")
+            budget_remaining -= len(procedures_text)
+
+        # 3. User preferences from global memory
+        preferences_text = self._extract_user_preferences(
+            global_memory, budget_remaining
+        )
+        if preferences_text:
+            sections.append(f"## User Preferences\n{preferences_text}")
+
+        # If no context was gathered, return raw prompt
+        if not sections:
+            return task_prompt
+
+        # Compose the enriched prompt
+        delegation_header = "# DELEGATION CONTEXT"
+        if parent_persona_name:
+            delegation_header += f"\nDelegated by: {parent_persona_name}"
+
+        context_block = f"{delegation_header}\n\n" + "\n\n".join(sections)
+
+        return f"{context_block}\n\n# TASK\n{task_prompt}"
+
+    def _extract_memory_excerpt(
+        self,
+        parent_memory: MemoryManager,
+        task_prompt: str,
+        budget: int,
+    ) -> str:
+        """Extract relevant sections from parent's MEMORY.md."""
+        raw_memory = parent_memory.read_memory().strip()
+        if not raw_memory or raw_memory == "# MEMORY":
+            return ""
+
+        # Parse sections and score by keyword overlap with task
+        task_tokens = set(task_prompt.lower().split())
+        sections = self._parse_memory_sections(raw_memory)
+
+        scored: list[tuple[float, str]] = []
+        for title, body in sections:
+            section_tokens = set(title.lower().split()) | set(body.lower().split()[:50])
+            overlap = len(task_tokens & section_tokens)
+            if overlap > 0:
+                scored.append((overlap, f"**{title}**: {body.strip()}"))
+
+        if not scored:
+            return ""
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+
+        # Collect sections within budget
+        lines: list[str] = []
+        used = 0
+        for _score, text in scored:
+            if used + len(text) > budget:
+                # Truncate the last fitting section
+                remaining = budget - used
+                if remaining > 50:
+                    lines.append(text[:remaining] + "...")
+                break
+            lines.append(text)
+            used += len(text) + 1  # +1 for newline
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _parse_memory_sections(content: str) -> list[tuple[str, str]]:
+        """Parse MEMORY.md into (title, body) pairs for ## sections."""
+        sections: list[tuple[str, str]] = []
+        current_title = ""
+        current_lines: list[str] = []
+
+        for line in content.splitlines():
+            if line.startswith("## "):
+                if current_title:
+                    sections.append((current_title, "\n".join(current_lines).strip()))
+                current_title = line[3:].strip()
+                current_lines = []
+            elif current_title:
+                current_lines.append(line)
+
+        if current_title:
+            sections.append((current_title, "\n".join(current_lines).strip()))
+
+        return sections
+
+    def _extract_procedures(
+        self,
+        parent_memory: MemoryManager,
+        task_prompt: str,
+        global_memory: Optional[GlobalMemoryManager],
+        budget: int,
+    ) -> str:
+        """Extract matching procedures from parent's procedure store."""
+        global_procedures = []
+        if global_memory:
+            global_procedures = global_memory.procedures.list_procedures()
+
+        matched = parent_memory.match_procedures(
+            task_prompt,
+            global_procedures=global_procedures,
+            limit=self.procedure_limit,
+        )
+
+        if not matched:
+            return ""
+
+        lines: list[str] = []
+        used = 0
+        for proc in matched:
+            entry_lines = [f"**{proc.title}** (trigger: {proc.trigger})"]
+            for i, step in enumerate(proc.steps, 1):
+                entry_lines.append(f"  {i}. {step}")
+            entry = "\n".join(entry_lines)
+
+            if used + len(entry) > budget:
+                break
+            lines.append(entry)
+            used += len(entry) + 1
+
+        return "\n".join(lines)
+
+    @staticmethod
+    def _extract_user_preferences(
+        global_memory: Optional[GlobalMemoryManager],
+        budget: int,
+    ) -> str:
+        """Extract user preferences from global memory."""
+        if not global_memory:
+            return ""
+
+        user_memory = global_memory.read_user_memory().strip()
+        if not user_memory or user_memory == "# USER":
+            return ""
+
+        # Truncate to budget
+        if len(user_memory) > budget:
+            return user_memory[:budget] + "..."
+
+        return user_memory

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -1,0 +1,173 @@
+"""Tests for HandoffBuilder — structured delegation context enrichment."""
+
+from __future__ import annotations
+
+import pytest
+
+from g3lobster.memory.global_memory import GlobalMemoryManager
+from g3lobster.memory.handoff import HandoffBuilder
+from g3lobster.memory.manager import MemoryManager
+
+
+@pytest.fixture
+def memory(tmp_path):
+    return MemoryManager(data_dir=str(tmp_path / "agent"), compact_threshold=100)
+
+
+@pytest.fixture
+def global_memory(tmp_path):
+    return GlobalMemoryManager(str(tmp_path / "global"))
+
+
+class TestHandoffBuilderBuild:
+    def test_returns_raw_prompt_when_no_context(self, memory):
+        """When parent has empty memory and no procedures, return raw prompt."""
+        builder = HandoffBuilder()
+        result = builder.build("do something", memory)
+        assert result == "do something"
+
+    def test_includes_memory_excerpts(self, memory):
+        """Relevant memory sections appear in handoff."""
+        memory.write_memory(
+            "# MEMORY\n\n"
+            "## Dashboard Config\n\nUse dark theme for dashboards.\n\n"
+            "## Unrelated\n\nSomething about cats.\n"
+        )
+        builder = HandoffBuilder()
+        result = builder.build("build a dashboard", memory)
+
+        assert "# DELEGATION CONTEXT" in result
+        assert "## Parent Memory Excerpts" in result
+        assert "Dashboard Config" in result
+        assert "dark theme" in result
+        assert "# TASK" in result
+        assert "build a dashboard" in result
+
+    def test_includes_matching_procedures(self, memory):
+        """Matching procedures from parent are included."""
+        memory.procedure_store.save_procedures([
+            _make_procedure("Deploy Dashboard", "deploy dashboard", [
+                "Run build", "Upload artifacts", "Verify health"
+            ]),
+        ])
+        builder = HandoffBuilder()
+        result = builder.build("deploy dashboard", memory)
+
+        assert "## Suggested Procedures" in result
+        assert "Deploy Dashboard" in result
+        assert "Run build" in result
+
+    def test_includes_user_preferences(self, memory, global_memory):
+        """User preferences from global memory are included."""
+        global_memory.write_user_memory("# USER\n\nAlways use TypeScript.\n")
+        builder = HandoffBuilder()
+        result = builder.build("write some code", memory, global_memory=global_memory)
+
+        assert "## User Preferences" in result
+        assert "Always use TypeScript" in result
+
+    def test_includes_parent_persona_name(self, memory):
+        """Parent persona name appears in delegation header."""
+        memory.write_memory(
+            "# MEMORY\n\n## Task Notes\n\nImportant task context.\n"
+        )
+        builder = HandoffBuilder()
+        result = builder.build("do task work", memory, parent_persona_name="Athena")
+
+        assert "Delegated by: Athena" in result
+
+    def test_respects_budget(self, memory):
+        """Handoff context is bounded by max_context_chars."""
+        # Write a large memory section
+        big_content = "x " * 5000
+        memory.write_memory(f"# MEMORY\n\n## Big Section\n\n{big_content}\n")
+
+        builder = HandoffBuilder(max_context_chars=200)
+        result = builder.build("find big data", memory)
+
+        # The context portion (excluding the TASK section) should be bounded
+        parts = result.split("# TASK\n")
+        assert len(parts) == 2
+        context_part = parts[0]
+        # Context should not contain the full 10000 chars
+        assert len(context_part) < 500
+
+    def test_handles_empty_global_memory(self, memory, global_memory):
+        """Empty global memory produces no user preferences section."""
+        builder = HandoffBuilder()
+        result = builder.build("do something", memory, global_memory=global_memory)
+        assert result == "do something"
+
+    def test_all_sections_together(self, memory, global_memory):
+        """All three sections appear when data is available."""
+        memory.write_memory(
+            "# MEMORY\n\n## Deploy Notes\n\nAlways deploy to staging first.\n"
+        )
+        memory.procedure_store.save_procedures([
+            _make_procedure("Deploy App", "deploy application", [
+                "Build Docker image", "Push to registry", "Update k8s"
+            ]),
+        ])
+        global_memory.write_user_memory("# USER\n\nPrefer verbose logging.\n")
+
+        builder = HandoffBuilder()
+        result = builder.build(
+            "deploy application",
+            memory,
+            global_memory=global_memory,
+            parent_persona_name="Hermes",
+        )
+
+        assert "# DELEGATION CONTEXT" in result
+        assert "Delegated by: Hermes" in result
+        assert "## Parent Memory Excerpts" in result
+        assert "## Suggested Procedures" in result
+        assert "## User Preferences" in result
+        assert "# TASK" in result
+        assert "deploy application" in result
+
+
+class TestHandoffBuilderEdgeCases:
+    def test_zero_matching_memory_sections(self, memory):
+        """No memory sections match the task — no excerpt in output."""
+        memory.write_memory(
+            "# MEMORY\n\n## Cooking Recipes\n\nMake pasta with garlic.\n"
+        )
+        builder = HandoffBuilder()
+        result = builder.build("deploy kubernetes", memory)
+
+        # No overlap → no context → raw prompt
+        assert result == "deploy kubernetes"
+
+    def test_procedure_budget_overflow(self, memory):
+        """Procedures exceeding budget are truncated."""
+        procs = [
+            _make_procedure(
+                f"Proc {i}", f"task procedure {i}",
+                [f"Step {j} for procedure {i}" for j in range(5)],
+            )
+            for i in range(10)
+        ]
+        memory.procedure_store.save_procedures(procs)
+
+        builder = HandoffBuilder(max_context_chars=200, procedure_limit=10)
+        result = builder.build("task procedure", memory)
+
+        # Should contain some procedures but not all 10
+        assert "Suggested Procedures" in result
+
+    def test_custom_budget_and_limit(self, memory):
+        """Custom max_context_chars and procedure_limit are respected."""
+        builder = HandoffBuilder(max_context_chars=500, procedure_limit=1)
+        assert builder.max_context_chars == 500
+        assert builder.procedure_limit == 1
+
+    def test_min_budget_floor(self):
+        """Budget below 100 is clamped to 100."""
+        builder = HandoffBuilder(max_context_chars=10)
+        assert builder.max_context_chars == 100
+
+
+def _make_procedure(title, trigger, steps):
+    from g3lobster.memory.procedures import Procedure
+    return Procedure(title=title, trigger=trigger, steps=steps, weight=10.0, status="permanent")


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #73.

Enriches the delegation boundary so child agents receive structured context from the parent — memory excerpts, matching procedures, and user preferences — without blowing token budgets. A new `HandoffBuilder` class constructs a budget-aware enriched prompt, used by both `delegate_task()` and `delegate_task_stream()`.

## Changes
- **New `g3lobster/memory/handoff.py`**: `HandoffBuilder` class with configurable `max_context_chars` (default 2000) and `procedure_limit` (default 3). Builds structured prompts with `# DELEGATION CONTEXT` / `## Parent Memory Excerpts` / `## Suggested Procedures` / `## User Preferences` / `# TASK` sections.
- **Modified `g3lobster/agents/registry.py`**: Added `_build_handoff()` helper; `delegate_task()` and `delegate_task_stream()` now enrich prompts via HandoffBuilder before creating child Tasks. Raw task string preserved in `SubagentRun.task` for audit trail.
- **New `tests/test_handoff.py`**: 12 unit tests covering memory excerpts, procedure matching, user preferences, budget enforcement, empty/missing context, and edge cases.

## Verification
- `pytest tests/test_handoff.py`: 12/12 passing
- `pytest tests/test_delegation_api.py`: 8/8 passing (existing tests unbroken)
- `pytest tests/test_memory.py tests/test_global_memory.py tests/test_subagent_registry.py`: 26/26 passing

Closes #73