### PR TITLE
feat: Multi-layer context builder with token budgeting

### DIFF
--- a/g3lobster/memory/context.py
+++ b/g3lobster/memory/context.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
+import logging
+from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional
 
 from g3lobster.memory.global_memory import GlobalMemoryManager
 from g3lobster.memory.manager import MemoryManager
 from g3lobster.memory.procedures import Procedure
 
+logger = logging.getLogger(__name__)
 
 _STRUCTURE_PREAMBLE_TEMPLATE = """\
 # G3Lobster Agent Environment
@@ -25,8 +28,56 @@ reaching you — you do not need to implement them yourself.\
 """
 
 
+def _estimate_tokens(text: str) -> int:
+    """Approximate token count using len(text) // 4."""
+    return len(text) // 4
+
+
+@dataclass
+class ContextLayer:
+    """A single layer of context with a name, priority, and content."""
+
+    name: str
+    priority: int
+    content: str
+    required: bool = False
+
+    @property
+    def tokens(self) -> int:
+        return _estimate_tokens(self.content)
+
+
+@dataclass
+class BuildInfo:
+    """Debug info from the last build() call."""
+
+    included: List[Dict[str, Any]] = field(default_factory=list)
+    dropped: List[Dict[str, Any]] = field(default_factory=list)
+    total_tokens: int = 0
+    budget: int = 0
+
+
+# Display order for assembling the final prompt (layer name -> position).
+_DISPLAY_ORDER = [
+    "preamble",
+    "persona",
+    "available_agents",
+    "user_prefs",
+    "memory",
+    "recollection",
+    "procedures",
+    "compaction",
+    "messages",
+    "prompt",
+]
+
+
 class ContextBuilder:
-    """Builds request context from MEMORY.md + recent transcript entries."""
+    """Builds request context from MEMORY.md + recent transcript entries.
+
+    Supports priority-based layer dropping when the assembled context exceeds
+    a configurable token budget.
+    """
 
     def __init__(
         self,
@@ -36,6 +87,8 @@ class ContextBuilder:
         global_memory_manager: Optional[GlobalMemoryManager] = None,
         procedure_limit: int = 3,
         agent_list_provider: Optional[Callable[[], List[Dict[str, Any]]]] = None,
+        token_budget: int = 1_000_000,
+        debug: bool = False,
     ):
         self.memory_manager = memory_manager
         self.message_limit = message_limit
@@ -43,6 +96,9 @@ class ContextBuilder:
         self.global_memory_manager = global_memory_manager
         self.procedure_limit = max(1, int(procedure_limit))
         self.agent_list_provider = agent_list_provider
+        self.token_budget = token_budget
+        self.debug = debug
+        self.last_build_info: Optional[BuildInfo] = None
 
     def _structure_preamble(self) -> str:
         data_dir = str(self.memory_manager.data_dir)
@@ -56,9 +112,21 @@ class ContextBuilder:
             global_data_dir=global_data_dir,
         )
 
+    def _recollection_layer(self) -> str:
+        """Return recollection content from the association graph.
+
+        This is a no-op stub until issue #63 (salience-classified journal /
+        association graph) is merged.  Once #63 lands, this method should query
+        the recollection system for contextually relevant memories.
+        """
+        return ""
+
     def build(self, session_id: str, prompt: str) -> str:
+        # --- gather raw content for each layer ---
         memory_text = self.memory_manager.read_memory().strip()
-        recent_entries = self.memory_manager.read_session_messages(session_id, limit=self.message_limit)
+        recent_entries = self.memory_manager.read_session_messages(
+            session_id, limit=self.message_limit
+        )
         compaction = self.memory_manager.read_latest_compaction(session_id) or {}
 
         user_memory = "(empty)"
@@ -83,49 +151,145 @@ class ContextBuilder:
                 continue
             history_lines.append(f"{role}: {content}")
 
-        parts = [self._structure_preamble(), ""]
-        if self.system_preamble:
-            parts.extend(
-                [
-                    "# Agent Persona",
-                    self.system_preamble,
-                    "",
-                ]
-            )
-
+        # --- build delegation section ---
         delegation_section = self._format_available_agents()
+        agents_content = ""
         if delegation_section:
-            parts.extend(
-                [
-                    "# Available Agents for Delegation",
-                    "You can delegate tasks to other agents using the delegate_to_agent tool.",
-                    delegation_section,
-                    "",
-                ]
+            agents_content = (
+                "# Available Agents for Delegation\n"
+                "You can delegate tasks to other agents using the delegate_to_agent tool.\n"
+                + delegation_section
             )
 
-        parts.extend(
-            [
-                "# User Preferences",
-                user_memory,
-                "",
-                "# Agent Memory",
-                memory_text or "(empty)",
-                "",
-                "# Known Procedures",
-                self._format_procedures(matched),
-                "",
-                "# Compaction Summary",
-                str(compaction.get("summary", "")).strip() or "(none)",
-                "",
-                "# Recent Conversation",
-                "\n".join(history_lines) if history_lines else "(none)",
-                "",
-                "# New User Prompt",
-                prompt.strip(),
-            ]
+        # --- build persona section ---
+        persona_content = ""
+        if self.system_preamble:
+            persona_content = "# Agent Persona\n" + self.system_preamble
+
+        # --- recollection stub ---
+        recollection_content = self._recollection_layer()
+
+        # --- construct layers ---
+        layers: List[ContextLayer] = [
+            ContextLayer(
+                name="preamble",
+                priority=0,
+                content=self._structure_preamble(),
+                required=True,
+            ),
+            ContextLayer(
+                name="persona",
+                priority=1,
+                content=persona_content,
+                required=True,
+            ),
+            ContextLayer(
+                name="prompt",
+                priority=2,
+                content="# New User Prompt\n" + prompt.strip(),
+                required=True,
+            ),
+            ContextLayer(
+                name="messages",
+                priority=3,
+                content=(
+                    "# Recent Conversation\n"
+                    + ("\n".join(history_lines) if history_lines else "(none)")
+                ),
+            ),
+            ContextLayer(
+                name="memory",
+                priority=4,
+                content="# Agent Memory\n" + (memory_text or "(empty)"),
+            ),
+            ContextLayer(
+                name="user_prefs",
+                priority=5,
+                content="# User Preferences\n" + user_memory,
+            ),
+            ContextLayer(
+                name="available_agents",
+                priority=6,
+                content=agents_content,
+            ),
+            ContextLayer(
+                name="recollection",
+                priority=7,
+                content=recollection_content,
+            ),
+            ContextLayer(
+                name="procedures",
+                priority=8,
+                content="# Known Procedures\n" + self._format_procedures(matched),
+            ),
+            ContextLayer(
+                name="compaction",
+                priority=9,
+                content=(
+                    "# Compaction Summary\n"
+                    + (str(compaction.get("summary", "")).strip() or "(none)")
+                ),
+            ),
+        ]
+
+        # --- apply token budget with priority-based dropping ---
+        included, dropped = self._apply_budget(layers)
+
+        # --- record debug info ---
+        if self.debug:
+            info = BuildInfo(budget=self.token_budget)
+            for layer in included:
+                info.included.append(
+                    {"name": layer.name, "tokens": layer.tokens, "priority": layer.priority}
+                )
+            for layer in dropped:
+                info.dropped.append(
+                    {"name": layer.name, "tokens": layer.tokens, "priority": layer.priority}
+                )
+            info.total_tokens = sum(l.tokens for l in included)
+            self.last_build_info = info
+            logger.debug(
+                "context build: %d layers included (%d tokens), %d dropped, budget=%d",
+                len(included),
+                info.total_tokens,
+                len(dropped),
+                self.token_budget,
+            )
+
+        # --- assemble in display order ---
+        layer_map = {layer.name: layer for layer in included}
+        parts: List[str] = []
+        for name in _DISPLAY_ORDER:
+            layer = layer_map.get(name)
+            if layer and layer.content:
+                parts.append(layer.content)
+
+        return "\n\n".join(parts).strip() + "\n"
+
+    def _apply_budget(
+        self, layers: List[ContextLayer]
+    ) -> tuple[List[ContextLayer], List[ContextLayer]]:
+        """Drop lowest-priority (highest priority number) layers until under budget."""
+        total = sum(l.tokens for l in layers)
+        if total <= self.token_budget:
+            return layers, []
+
+        # Sort by priority descending (lowest importance first) for dropping
+        droppable = sorted(
+            [l for l in layers if not l.required],
+            key=lambda l: l.priority,
+            reverse=True,
         )
-        return "\n".join(parts).strip() + "\n"
+        dropped: List[ContextLayer] = []
+        for layer in droppable:
+            if total <= self.token_budget:
+                break
+            total -= layer.tokens
+            dropped.append(layer)
+
+        dropped_names = {l.name for l in dropped}
+        included = [l for l in layers if l.name not in dropped_names]
+        return included, dropped
 
     def _format_available_agents(self) -> str:
         """Format the list of available sibling agents for the preamble."""

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from g3lobster.memory.context import ContextBuilder
+from g3lobster.memory.context import ContextBuilder, ContextLayer, _estimate_tokens
 from g3lobster.memory.manager import MemoryManager
 
 
@@ -46,3 +46,88 @@ def test_tagged_memory_append_and_read(tmp_path) -> None:
 
     ops_entries = memory.get_memories_by_tag("ops")
     assert ops_entries == ["Pager rotation starts Monday."]
+
+
+def test_context_builder_drops_low_priority_layers(tmp_path) -> None:
+    """With a tiny budget, required layers survive but droppable layers are dropped."""
+    memory = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=40)
+    memory.write_memory("A" * 400)  # ~100 tokens
+
+    builder = ContextBuilder(
+        memory_manager=memory,
+        message_limit=4,
+        system_preamble="You are a test agent.",
+        token_budget=200,  # very tight budget
+        debug=True,
+    )
+    prompt = builder.build("sess-1", "hello")
+
+    # Required layers (preamble, persona, prompt) must survive
+    assert "# G3Lobster Agent Environment" in prompt
+    assert "# Agent Persona" in prompt
+    assert "hello" in prompt
+
+    # Some droppable layers should have been dropped
+    info = builder.last_build_info
+    assert info is not None
+    assert len(info.dropped) > 0
+    dropped_names = {d["name"] for d in info.dropped}
+    # The lowest priority layers (compaction=9, procedures=8) should be first to drop
+    assert "compaction" in dropped_names or "procedures" in dropped_names
+
+
+def test_context_builder_debug_info(tmp_path) -> None:
+    """Debug mode populates last_build_info with layer details."""
+    memory = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=40)
+
+    builder = ContextBuilder(
+        memory_manager=memory,
+        message_limit=4,
+        debug=True,
+    )
+    builder.build("sess-1", "test prompt")
+
+    info = builder.last_build_info
+    assert info is not None
+    assert info.budget == 1_000_000
+    assert info.total_tokens > 0
+    included_names = {entry["name"] for entry in info.included}
+    assert "preamble" in included_names
+    assert "prompt" in included_names
+    for entry in info.included:
+        assert "tokens" in entry
+        assert "priority" in entry
+
+
+def test_context_builder_default_budget_includes_all(tmp_path) -> None:
+    """Default budget (1M tokens) should include all layers — backward compat."""
+    memory = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=40)
+    memory.write_memory("Some memory content here.")
+
+    builder = ContextBuilder(
+        memory_manager=memory,
+        message_limit=4,
+        system_preamble="Be helpful.",
+        debug=True,
+    )
+    prompt = builder.build("sess-1", "what's up?")
+
+    info = builder.last_build_info
+    assert info is not None
+    assert len(info.dropped) == 0
+
+    # All sections present
+    assert "# Agent Persona" in prompt
+    assert "# Agent Memory" in prompt
+    assert "# User Preferences" in prompt
+    assert "# Known Procedures" in prompt
+    assert "# Compaction Summary" in prompt
+    assert "# Recent Conversation" in prompt
+    assert "# New User Prompt" in prompt
+
+
+def test_context_layer_token_estimation() -> None:
+    """ContextLayer.tokens uses len//4 estimation."""
+    layer = ContextLayer(name="test", priority=0, content="A" * 100)
+    assert layer.tokens == 25
+    assert _estimate_tokens("B" * 200) == 50


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #64.

Replaces g3lobster's flat context assembly with a priority-layered context builder that respects a configurable token budget. Higher-priority layers (preamble, persona, user prompt) are always included as required layers, while lower-priority layers (procedures, compaction, agents list) are dropped gracefully when the budget is exceeded. A recollection layer stub is included for future integration with #63's association graph.

## Changes
- Added `ContextLayer` dataclass with `name`, `priority`, `content`, and `required` fields
- Added `_estimate_tokens()` helper using `len(text) // 4` approximation
- Added `token_budget` (default 1M) and `debug` parameters to `ContextBuilder.__init__()`
- Refactored `build()` to construct `ContextLayer` objects with numbered priorities and assemble in display order
- Added `_apply_budget()` method that drops lowest-priority layers when over budget
- Added `_recollection_layer()` stub for #63 integration
- Added `BuildInfo` dataclass and `last_build_info` attribute for debug introspection
- Added 4 new tests: drop behavior, debug info, default budget backward compat, token estimation
- Existing test `test_memory_manager_and_context_builder_with_persona_preamble` still passes

## Verification
- `python3 -m pytest tests/test_memory.py`: 6/6 passing

Closes #64