### PR TITLE
feat: cross-agent knowledge sharing (tell one agent, another knows)

### DIFF
--- a/docs/memory-architecture.md
+++ b/docs/memory-architecture.md
@@ -112,9 +112,24 @@ Manages shared state under `data/.memory/`:
 | `USER.md` | Global user preferences (fallback for all agents) |
 | `users/{id}/USER.md` | Per-user preferences (overrides global) |
 | `PROCEDURES.md` | Global procedures shared across all agents |
-| `knowledge/*.md` | Custom knowledge files |
+| `knowledge/*.md` | Cross-agent knowledge files with YAML frontmatter |
 
 User IDs are sanitized (`re.sub(r"[^a-zA-Z0-9_.-]", "_", user_id)`) to prevent path traversal.
+
+**Knowledge file format:**
+```markdown
+---
+source: research-agent
+topic: api-migration
+created: 2026-03-11T04:30:00Z
+---
+
+# API Migration Delayed
+
+The API migration has been delayed until Q2.
+```
+
+Knowledge files are written via `GlobalMemoryManager.write_knowledge()` (thread-safe) and automatically injected into agent prompts by `ContextBuilder` when relevant to the current query.
 
 **Key class:** `GlobalMemoryManager` in `memory/global_memory.py`
 
@@ -130,9 +145,10 @@ When an agent receives a task, `ContextBuilder.build()` assembles the full promp
 │ 4. User preferences (USER.md)          │
 │ 5. Agent memory (MEMORY.md)            │
 │ 6. Matched procedures (top 3)          │
-│ 7. Latest compaction summary           │
-│ 8. Recent conversation (last N msgs)   │
-│ 9. New user prompt                     │
+│ 7. Cross-agent knowledge (top 3)       │
+│ 8. Latest compaction summary           │
+│ 9. Recent conversation (last N msgs)   │
+│ 10. New user prompt                    │
 └─────────────────────────────────────────┘
 ```
 

--- a/g3lobster/memory/context.py
+++ b/g3lobster/memory/context.py
@@ -2,11 +2,25 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any, Callable, Dict, List, Optional
 
-from g3lobster.memory.global_memory import GlobalMemoryManager
+from g3lobster.memory.global_memory import GlobalMemoryManager, _parse_frontmatter
 from g3lobster.memory.manager import MemoryManager
 from g3lobster.memory.procedures import Procedure
+
+_TOKEN_PATTERN = re.compile(r"[a-z0-9]+")
+
+_KNOWLEDGE_STOP_WORDS = {
+    "a", "an", "and", "are", "as", "at", "be", "by", "for", "from",
+    "how", "i", "in", "is", "it", "my", "of", "on", "or", "please",
+    "the", "this", "to", "we", "with", "you",
+}
+
+
+def _tokenize_for_matching(text: str) -> set[str]:
+    tokens = set(_TOKEN_PATTERN.findall(text.lower()))
+    return tokens - _KNOWLEDGE_STOP_WORDS
 
 
 _STRUCTURE_PREAMBLE_TEMPLATE = """\
@@ -42,6 +56,7 @@ class ContextBuilder:
         self.system_preamble = system_preamble.strip()
         self.global_memory_manager = global_memory_manager
         self.procedure_limit = max(1, int(procedure_limit))
+        self.knowledge_limit = 3
         self.agent_list_provider = agent_list_provider
 
     def _structure_preamble(self) -> str:
@@ -104,6 +119,8 @@ class ContextBuilder:
                 ]
             )
 
+        knowledge_section = self._build_knowledge_section(prompt)
+
         parts.extend(
             [
                 "# User Preferences",
@@ -115,6 +132,20 @@ class ContextBuilder:
                 "# Known Procedures",
                 self._format_procedures(matched),
                 "",
+            ]
+        )
+
+        if knowledge_section:
+            parts.extend(
+                [
+                    "# Cross-Agent Knowledge",
+                    knowledge_section,
+                    "",
+                ]
+            )
+
+        parts.extend(
+            [
                 "# Compaction Summary",
                 str(compaction.get("summary", "")).strip() or "(none)",
                 "",
@@ -149,6 +180,47 @@ class ContextBuilder:
                 entry += f": {description}"
             lines.append(entry)
         return "\n".join(lines)
+
+    def _build_knowledge_section(self, prompt: str) -> str:
+        """Match and format relevant cross-agent knowledge entries."""
+        if not self.global_memory_manager:
+            return ""
+        all_knowledge = self.global_memory_manager.read_all_knowledge()
+        if not all_knowledge:
+            return ""
+
+        query_tokens = _tokenize_for_matching(prompt)
+        if not query_tokens:
+            return ""
+
+        scored: list[tuple[float, str, str]] = []
+        for rel_path, content in all_knowledge.items():
+            meta = _parse_frontmatter(content)
+            # Build match text from title, topic, and body
+            body = content.split("---", 2)[-1].strip() if content.startswith("---") else content
+            match_text = f"{meta.get('topic', '')} {body}"
+            entry_tokens = _tokenize_for_matching(match_text)
+            if not entry_tokens:
+                continue
+            overlap = len(query_tokens & entry_tokens) / len(query_tokens | entry_tokens)
+            if overlap >= 0.1:
+                scored.append((overlap, rel_path, content))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+        top = scored[: self.knowledge_limit]
+        if not top:
+            return ""
+
+        lines: list[str] = []
+        for _score, _path, content in top:
+            meta = _parse_frontmatter(content)
+            body = content.split("---", 2)[-1].strip() if content.startswith("---") else content
+            source = meta.get("source", "unknown")
+            topic = meta.get("topic", "general")
+            lines.append(f"_Source: {source}, Topic: {topic}_")
+            lines.append(body)
+            lines.append("")
+        return "\n".join(lines).rstrip()
 
     @staticmethod
     def _format_procedures(procedures: List[Procedure]) -> str:

--- a/g3lobster/memory/global_memory.py
+++ b/g3lobster/memory/global_memory.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import re
 import threading
+from datetime import datetime, timezone
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 from g3lobster.memory.procedures import ProcedureStore, is_empty_procedure_document
 
@@ -20,6 +21,7 @@ class GlobalMemoryManager:
         self.procedures_file = self.memory_dir / "PROCEDURES.md"
         self.knowledge_dir = self.memory_dir / "knowledge"
         self._procedures_lock = threading.Lock()
+        self._knowledge_lock = threading.Lock()
 
         self.memory_dir.mkdir(parents=True, exist_ok=True)
         self.knowledge_dir.mkdir(parents=True, exist_ok=True)
@@ -72,3 +74,49 @@ class GlobalMemoryManager:
 
     def list_knowledge(self) -> List[str]:
         return sorted(str(path.relative_to(self.knowledge_dir)) for path in self.knowledge_dir.rglob("*") if path.is_file())
+
+    def list_knowledge_metadata(self) -> List[Dict[str, Any]]:
+        """List knowledge files with parsed YAML frontmatter metadata."""
+        result: List[Dict[str, Any]] = []
+        for rel_path in self.list_knowledge():
+            content = self.read_knowledge_file(rel_path)
+            meta = _parse_frontmatter(content)
+            meta["path"] = rel_path
+            result.append(meta)
+        return result
+
+    def read_knowledge_file(self, path: str) -> str:
+        """Read a single knowledge file by path relative to knowledge_dir."""
+        full_path = self.knowledge_dir / path
+        if not full_path.is_file():
+            return ""
+        return full_path.read_text(encoding="utf-8")
+
+    def read_all_knowledge(self) -> Dict[str, str]:
+        """Read all knowledge files. Returns {relative_path: content}."""
+        return {rel: self.read_knowledge_file(rel) for rel in self.list_knowledge()}
+
+    def write_knowledge(self, title: str, content: str, source_agent: str, topic: str) -> str:
+        """Write a knowledge file with YAML frontmatter. Returns the relative file path."""
+        slug = re.sub(r"[^a-zA-Z0-9]+", "-", title.lower()).strip("-")[:60] or "untitled"
+        filename = f"{slug}.md"
+        created = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        body = f"---\nsource: {source_agent}\ntopic: {topic}\ncreated: {created}\n---\n\n# {title}\n\n{content}\n"
+        with self._knowledge_lock:
+            (self.knowledge_dir / filename).write_text(body, encoding="utf-8")
+        return filename
+
+
+def _parse_frontmatter(text: str) -> Dict[str, Any]:
+    """Parse YAML frontmatter from a knowledge file into a dict."""
+    meta: Dict[str, Any] = {}
+    if not text.startswith("---"):
+        return meta
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return meta
+    for line in parts[1].strip().splitlines():
+        if ":" in line:
+            key, _, value = line.partition(":")
+            meta[key.strip()] = value.strip()
+    return meta

--- a/tests/test_global_memory.py
+++ b/tests/test_global_memory.py
@@ -214,3 +214,130 @@ def test_memory_manager_init_does_not_trigger_additional_migration(tmp_path, mon
     MemoryManager(data_dir=str(runtime_dir))
 
     assert calls["count"] == 1
+
+
+def test_write_knowledge_creates_file_with_frontmatter(tmp_path) -> None:
+    manager = GlobalMemoryManager(str(tmp_path / "data"))
+    filename = manager.write_knowledge(
+        title="API Migration Delayed",
+        content="The API migration is delayed until Q2.",
+        source_agent="research",
+        topic="api-migration",
+    )
+    assert filename == "api-migration-delayed.md"
+    content = (manager.knowledge_dir / filename).read_text(encoding="utf-8")
+    assert "source: research" in content
+    assert "topic: api-migration" in content
+    assert "created:" in content
+    assert "# API Migration Delayed" in content
+    assert "The API migration is delayed until Q2." in content
+
+
+def test_read_knowledge_file_returns_content(tmp_path) -> None:
+    manager = GlobalMemoryManager(str(tmp_path / "data"))
+    manager.write_knowledge("Test", "Hello world", "agent-a", "testing")
+    content = manager.read_knowledge_file("test.md")
+    assert "Hello world" in content
+
+
+def test_read_knowledge_file_missing_returns_empty(tmp_path) -> None:
+    manager = GlobalMemoryManager(str(tmp_path / "data"))
+    assert manager.read_knowledge_file("nonexistent.md") == ""
+
+
+def test_read_all_knowledge_returns_all_files(tmp_path) -> None:
+    manager = GlobalMemoryManager(str(tmp_path / "data"))
+    manager.write_knowledge("Fact A", "Content A", "agent-a", "topicA")
+    manager.write_knowledge("Fact B", "Content B", "agent-b", "topicB")
+    all_k = manager.read_all_knowledge()
+    assert len(all_k) == 2
+    assert "Content A" in all_k["fact-a.md"]
+    assert "Content B" in all_k["fact-b.md"]
+
+
+def test_list_knowledge_metadata_returns_parsed_frontmatter(tmp_path) -> None:
+    manager = GlobalMemoryManager(str(tmp_path / "data"))
+    manager.write_knowledge("My Fact", "some content", "iris", "scheduling")
+    metadata = manager.list_knowledge_metadata()
+    assert len(metadata) == 1
+    assert metadata[0]["source"] == "iris"
+    assert metadata[0]["topic"] == "scheduling"
+    assert metadata[0]["path"] == "my-fact.md"
+
+
+def test_context_builder_includes_relevant_knowledge(tmp_path) -> None:
+    global_manager = GlobalMemoryManager(str(tmp_path / "data"))
+    global_manager.write_user_memory("# USER\n\n")
+    global_manager.write_knowledge(
+        title="API Migration Delayed",
+        content="The API migration is delayed until Q2 due to resource constraints.",
+        source_agent="research",
+        topic="api-migration",
+    )
+
+    memory = MemoryManager(data_dir=str(tmp_path / "agent"), compact_threshold=50)
+    memory.write_memory("# MEMORY\n\n")
+
+    builder = ContextBuilder(
+        memory_manager=memory,
+        message_limit=6,
+        global_memory_manager=global_manager,
+    )
+    prompt = builder.build("sess-1", "Prepare for tomorrow's standup about the API migration")
+
+    assert "# Cross-Agent Knowledge" in prompt
+    assert "API Migration Delayed" in prompt
+    assert "Source: research" in prompt
+
+
+def test_context_builder_excludes_irrelevant_knowledge(tmp_path) -> None:
+    global_manager = GlobalMemoryManager(str(tmp_path / "data"))
+    global_manager.write_user_memory("# USER\n\n")
+    global_manager.write_knowledge(
+        title="Grocery List",
+        content="Buy milk, eggs, and bread from the store.",
+        source_agent="personal",
+        topic="shopping",
+    )
+
+    memory = MemoryManager(data_dir=str(tmp_path / "agent"), compact_threshold=50)
+    memory.write_memory("# MEMORY\n\n")
+
+    builder = ContextBuilder(
+        memory_manager=memory,
+        message_limit=6,
+        global_memory_manager=global_manager,
+    )
+    prompt = builder.build("sess-1", "Deploy the application to production servers")
+
+    assert "# Cross-Agent Knowledge" not in prompt
+    assert "Grocery List" not in prompt
+
+
+def test_cross_agent_knowledge_demo_scenario(tmp_path) -> None:
+    """Tell Agent A a fact, then Agent B should pick it up via ContextBuilder."""
+    global_manager = GlobalMemoryManager(str(tmp_path / "data"))
+    global_manager.write_user_memory("# USER\n\n")
+
+    # Agent A learns something and writes to global knowledge
+    global_manager.write_knowledge(
+        title="API Migration Delayed to Q2",
+        content="The API migration has been delayed until Q2 due to team resource constraints.",
+        source_agent="research-agent",
+        topic="api-migration",
+    )
+
+    # Agent B builds context for a related query
+    agent_b_memory = MemoryManager(data_dir=str(tmp_path / "agent-b"), compact_threshold=50)
+    agent_b_memory.write_memory("# MEMORY\n\nI handle meeting prep.\n")
+
+    builder = ContextBuilder(
+        memory_manager=agent_b_memory,
+        message_limit=6,
+        global_memory_manager=global_manager,
+    )
+    prompt = builder.build("sess-b", "Prepare for tomorrow's standup — any updates on the API migration?")
+
+    assert "API Migration Delayed" in prompt
+    assert "delayed until Q2" in prompt
+    assert "research-agent" in prompt


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #81.

Enables automatic cross-agent knowledge sharing so that insights learned by one agent propagate to others via the global memory layer. When Agent A stores knowledge (e.g., "API migration delayed to Q2"), Agent B's ContextBuilder automatically picks it up when processing a related query — without being told directly.

## Changes
- **`g3lobster/memory/global_memory.py`** — Added `write_knowledge()`, `read_knowledge_file()`, `read_all_knowledge()`, and `list_knowledge_metadata()` methods with YAML frontmatter (source, topic, created) and thread-safe writes via `_knowledge_lock`
- **`g3lobster/memory/context.py`** — Added `_build_knowledge_section()` that reads all global knowledge files, scores them against the current prompt using token overlap matching, and injects the top 3 most relevant entries as a "# Cross-Agent Knowledge" section in the assembled prompt
- **`tests/test_global_memory.py`** — Added 8 new tests covering knowledge CRUD, metadata parsing, context injection with relevant knowledge, exclusion of irrelevant knowledge, and the full cross-agent demo scenario
- **`docs/memory-architecture.md`** — Updated ContextBuilder prompt assembly diagram and documented the knowledge file format with frontmatter

## Verification
- `pytest`: 156 passed, 2 skipped (all pre-existing skips)

Closes #81