### PR TITLE
feat: markdown-to-Google-Chat formatter

### DIFF
--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 from g3lobster.chat.auth import get_authenticated_service
 from g3lobster.chat.commands import handle as handle_command
+from g3lobster.chat.formatter import format_for_google_chat
 from g3lobster.cli.parser import get_content_id
 from g3lobster.cli.streaming import StreamEventType, accumulate_text
 from g3lobster.tasks.types import Task, TaskStatus
@@ -343,7 +344,7 @@ class ChatBridge:
             await self.send_message(reply_text, thread_id=thread_id)
 
     async def send_message(self, text: str, thread_id: Optional[str] = None) -> dict:
-        body = {"text": text}
+        body = {"text": format_for_google_chat(text)}
         if thread_id:
             body["thread"] = {"name": thread_id}
 
@@ -353,7 +354,7 @@ class ChatBridge:
         return result or {}
 
     async def update_message(self, message_name: str, text: str) -> None:
-        body = {"text": text}
+        body = {"text": format_for_google_chat(text)}
         try:
             await asyncio.to_thread(
                 self.service.spaces()

--- a/g3lobster/chat/formatter.py
+++ b/g3lobster/chat/formatter.py
@@ -1,0 +1,64 @@
+"""Convert a subset of Markdown formatting to Google Chat markup.
+
+Supported conversions (outside fenced code blocks):
+  **bold**       -> *bold*
+  ~~strike~~     -> ~strike~
+  [text](url)    -> <url|text>
+  # Header       -> *Header*   (levels 1-6)
+"""
+
+import re
+
+# Pre-compiled patterns used inside _convert_segment.
+_BOLD_RE = re.compile(r"\*\*(.+?)\*\*", re.DOTALL)
+_STRIKE_RE = re.compile(r"~~(.+?)~~", re.DOTALL)
+_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
+_HEADER_RE = re.compile(r"^#{1,6}\s+(.+)$", re.MULTILINE)
+
+
+def _convert_segment(text: str) -> str:
+    """Apply all Markdown-to-Google-Chat conversions to a non-code segment."""
+    text = _BOLD_RE.sub(r"*\1*", text)
+    text = _STRIKE_RE.sub(r"~\1~", text)
+    text = _LINK_RE.sub(r"<\2|\1>", text)
+    text = _HEADER_RE.sub(r"*\1*", text)
+    return text
+
+
+def format_for_google_chat(text: str) -> str:
+    """Convert Markdown formatting to Google Chat markup.
+
+    Content inside fenced code blocks (delimited by triple back-ticks) is
+    preserved verbatim.  All other text is converted according to the rules
+    documented in the module docstring.
+
+    Parameters
+    ----------
+    text:
+        The Markdown-formatted input string.
+
+    Returns
+    -------
+    str
+        The string with Google Chat compatible markup.
+    """
+    if not text:
+        return text
+
+    # Split on fenced code block boundaries.  The regex captures the
+    # delimiter so that ``re.split`` includes the fence markers as separate
+    # list items we can use to track whether we are inside a code block.
+    parts = re.split(r"(```)", text)
+
+    result: list[str] = []
+    inside_code = False
+    for part in parts:
+        if part == "```":
+            inside_code = not inside_code
+            result.append(part)
+        elif inside_code:
+            result.append(part)
+        else:
+            result.append(_convert_segment(part))
+
+    return "".join(result)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import pytest
+
+from g3lobster.chat.formatter import format_for_google_chat
+
+
+class TestBoldConversion:
+    def test_bold_double_asterisks_to_single(self):
+        assert format_for_google_chat("**bold**") == "*bold*"
+
+    def test_bold_within_sentence(self):
+        assert format_for_google_chat("This is **bold** text") == "This is *bold* text"
+
+    def test_multiple_bold_segments(self):
+        result = format_for_google_chat("**one** and **two**")
+        assert result == "*one* and *two*"
+
+
+class TestStrikethroughConversion:
+    def test_strikethrough_double_tilde_to_single(self):
+        assert format_for_google_chat("~~strike~~") == "~strike~"
+
+    def test_strikethrough_within_sentence(self):
+        assert format_for_google_chat("This is ~~removed~~ text") == "This is ~removed~ text"
+
+
+class TestLinkConversion:
+    def test_markdown_link_to_google_chat_format(self):
+        assert format_for_google_chat("[text](https://example.com)") == "<https://example.com|text>"
+
+    def test_link_within_sentence(self):
+        result = format_for_google_chat("Visit [Google](https://google.com) now")
+        assert result == "Visit <https://google.com|Google> now"
+
+
+class TestHeaderConversion:
+    @pytest.mark.parametrize("level", range(1, 7))
+    def test_header_levels_1_through_6(self, level):
+        hashes = "#" * level
+        result = format_for_google_chat(f"{hashes} Header")
+        assert result == "*Header*"
+
+    def test_header_preserves_content(self):
+        assert format_for_google_chat("# My Title") == "*My Title*"
+
+    def test_header_level_2(self):
+        assert format_for_google_chat("## Subtitle") == "*Subtitle*"
+
+
+class TestCombinedFormatting:
+    def test_bold_and_strikethrough_in_one_string(self):
+        result = format_for_google_chat("**bold** and ~~strike~~")
+        assert result == "*bold* and ~strike~"
+
+    def test_link_and_bold_in_one_string(self):
+        result = format_for_google_chat("**Click** [here](https://example.com)")
+        assert result == "*Click* <https://example.com|here>"
+
+
+class TestPassthrough:
+    def test_empty_string(self):
+        assert format_for_google_chat("") == ""
+
+    def test_plain_text_unchanged(self):
+        assert format_for_google_chat("Hello world") == "Hello world"
+
+    def test_plain_text_with_punctuation(self):
+        text = "No markdown here, just plain text!"
+        assert format_for_google_chat(text) == text
+
+
+class TestCodeBlockPreservation:
+    def test_bold_inside_code_block_not_converted(self):
+        text = "```\n**bold**\n```"
+        result = format_for_google_chat(text)
+        assert "**bold**" in result
+
+    def test_link_inside_code_block_not_converted(self):
+        text = "```\n[text](url)\n```"
+        result = format_for_google_chat(text)
+        assert "[text](url)" in result
+
+    def test_formatting_outside_code_block_still_converted(self):
+        text = "**bold** before\n```\n**not bold**\n```\n**bold** after"
+        result = format_for_google_chat(text)
+        assert "*bold* before" in result
+        assert "*bold* after" in result
+        assert "**not bold**" in result
+
+
+class TestMultiLineFormatting:
+    def test_multiple_lines_with_mixed_formatting(self):
+        text = "# Title\n\nSome **bold** text\n\n~~removed~~ item\n\n[link](https://example.com)"
+        result = format_for_google_chat(text)
+        assert "*Title*" in result
+        assert "*bold*" in result
+        assert "~removed~" in result
+        assert "<https://example.com|link>" in result
+
+    def test_multiline_preserves_line_structure(self):
+        text = "Line one\nLine two\nLine three"
+        result = format_for_google_chat(text)
+        assert "Line one" in result
+        assert "Line two" in result
+        assert "Line three" in result
+
+
+class TestNestedBoldInHeaders:
+    def test_bold_inside_header(self):
+        result = format_for_google_chat("# **Important**")
+        assert "*Important*" in result
+
+    def test_header_with_bold_word(self):
+        result = format_for_google_chat("## A **key** point")
+        assert "*A " in result or "A " in result
+        assert "point*" in result


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #84.

Adds a markdown-to-Google-Chat formatting layer so agent responses render correctly in Google Chat. The formatter converts standard markdown syntax (bold, strikethrough, links, headers) to Google Chat's native markup at the send/update boundary, preserving content inside fenced code blocks.

## Changes
- Created `g3lobster/chat/formatter.py` with `format_for_google_chat()` pure function
  - `**bold**` → `*bold*`
  - `~~strike~~` → `~strike~`
  - `[text](url)` → `<url|text>`
  - `# Header` → `*Header*` (all levels 1-6)
  - Preserves content inside fenced code blocks
- Integrated formatter in `ChatBridge.send_message()` and `ChatBridge.update_message()`
- Created `tests/test_formatter.py` with 27 unit tests covering all conversion rules and edge cases

## Verification
- `pytest tests/test_formatter.py`: 27 passed
- `pytest tests/`: 175 passed, 2 skipped

Closes #84