### PR TITLE
feat: live thinking SSE panel in web console

### DIFF
--- a/g3lobster/api/event_bus.py
+++ b/g3lobster/api/event_bus.py
@@ -1,0 +1,45 @@
+"""Lightweight pub/sub event bus for SSE streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from contextlib import asynccontextmanager
+from typing import AsyncIterator, Dict
+
+logger = logging.getLogger(__name__)
+
+
+class EventBus:
+    """Per-agent pub/sub using asyncio.Queue per subscriber."""
+
+    def __init__(self) -> None:
+        self._subscribers: Dict[str, list[asyncio.Queue]] = {}
+
+    def publish(self, agent_id: str, event: dict) -> None:
+        """Publish an event to all subscribers for the given agent."""
+        queues = self._subscribers.get(agent_id)
+        if not queues:
+            return
+        for queue in queues:
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:
+                logger.debug("Dropping event for agent %s — subscriber queue full", agent_id)
+
+    @asynccontextmanager
+    async def subscribe(self, agent_id: str, max_queue: int = 256) -> AsyncIterator[asyncio.Queue]:
+        """Context manager that yields a Queue receiving events for agent_id."""
+        queue: asyncio.Queue = asyncio.Queue(maxsize=max_queue)
+        self._subscribers.setdefault(agent_id, []).append(queue)
+        try:
+            yield queue
+        finally:
+            queues = self._subscribers.get(agent_id)
+            if queues:
+                try:
+                    queues.remove(queue)
+                except ValueError:
+                    pass
+                if not queues:
+                    del self._subscribers[agent_id]

--- a/g3lobster/api/routes_thinking.py
+++ b/g3lobster/api/routes_thinking.py
@@ -1,0 +1,44 @@
+"""SSE endpoint for live agent thinking events."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/agents", tags=["thinking"])
+
+HEARTBEAT_INTERVAL_S = 15
+
+
+@router.get("/{agent_id}/stream")
+async def stream_thinking(agent_id: str, request: Request) -> StreamingResponse:
+    """SSE endpoint that streams live thinking events for an agent."""
+    event_bus = request.app.state.event_bus
+
+    async def event_generator():
+        async with event_bus.subscribe(agent_id) as queue:
+            while True:
+                try:
+                    event = await asyncio.wait_for(queue.get(), timeout=HEARTBEAT_INTERVAL_S)
+                    yield f"data: {json.dumps(event)}\n\n"
+                except asyncio.TimeoutError:
+                    # Send heartbeat to keep connection alive
+                    yield ": heartbeat\n\n"
+                except asyncio.CancelledError:
+                    break
+
+    return StreamingResponse(
+        event_generator(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/g3lobster/api/server.py
+++ b/g3lobster/api/server.py
@@ -25,8 +25,10 @@ from g3lobster.api.routes_standup import router as standup_router
 from g3lobster.api.routes_delegation import router as delegation_router
 from g3lobster.api.routes_export import router as export_router
 from g3lobster.api.routes_health import router as health_router
+from g3lobster.api.routes_thinking import router as thinking_router
 from g3lobster.api.routes_metrics import router as metrics_router
 from g3lobster.api.routes_setup import router as setup_router
+from g3lobster.api.event_bus import EventBus
 from g3lobster.config import AppConfig
 
 
@@ -46,6 +48,7 @@ def create_app(
     control_plane: Optional[object] = None,
     standup_store: Optional[object] = None,
     standup_orchestrator: Optional[object] = None,
+    event_bus: Optional[EventBus] = None,
 ) -> FastAPI:
     runtime_config = config or AppConfig()
     runtime_config_path = str(Path(config_path or "config.yaml").expanduser().resolve())
@@ -98,6 +101,7 @@ def create_app(
     app.state.standup_store = standup_store
     app.state.standup_orchestrator = standup_orchestrator
     app.state._stopped_memory_managers = {}
+    app.state.event_bus = event_bus or EventBus()
 
     _AUTH_EXEMPT_PREFIXES = ("/health", "/setup", "/chat/events", "/docs", "/openapi.json", "/ui")
 
@@ -128,6 +132,7 @@ def create_app(
     app.include_router(standup_router)
     app.include_router(calendar_router)
     app.include_router(calendar_setup_router)
+    app.include_router(thinking_router)
 
     static_dir = Path(__file__).resolve().parent.parent / "static"
     if static_dir.is_dir():

--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -91,6 +91,7 @@ class ChatBridge:
         concierge_agent_id: Optional[str] = None,
         debounce_window_ms: int = 2000,
         stream_update_interval_s: float = 1.0,
+        event_bus: Optional[object] = None,
     ):
         self.registry = registry
         self.poll_interval_s = poll_interval_s
@@ -103,6 +104,7 @@ class ChatBridge:
         self.standup_orchestrator = standup_orchestrator
         self.debug_mode = debug_mode
         self.concierge_agent_id = concierge_agent_id
+        self.event_bus = event_bus
 
         self.space_id = space_id
         self._poll_task: Optional[asyncio.Task] = None
@@ -402,6 +404,15 @@ class ChatBridge:
             space_id=self.space_id,
         )
 
+        # Emit user_input event to SSE subscribers
+        if self.event_bus:
+            sender_name = sender.get("displayName") or sender.get("name") or "unknown"
+            self.event_bus.publish(target_id, {
+                "type": "user_input",
+                "sender": sender_name,
+                "text": text,
+            })
+
         thinking_msg = await self.send_message(
             f"{persona.emoji} _{persona.name} is thinking..._",
             thread_id=thread_id,
@@ -417,6 +428,15 @@ class ChatBridge:
 
         async for event in runtime.assign_stream(task):
             stream_events.append(event)
+
+            # Publish streaming event to SSE subscribers
+            if self.event_bus:
+                self.event_bus.publish(target_id, {
+                    "type": event.event_type.value,
+                    "data": event.data,
+                    "text": event.text or None,
+                })
+
             if event.event_type == StreamEventType.TOOL_USE:
                 tool_name = _tool_name_for_display(event.data)
                 progress_text = _format_progress_text(persona, tool_name)
@@ -470,6 +490,15 @@ class ChatBridge:
         else:
             reply_text = f"{reply_persona.emoji} {reply_persona.name}: task finished with no output"
 
+        # Emit response event to SSE subscribers
+        if self.event_bus:
+            self.event_bus.publish(target_id, {
+                "type": "response",
+                "text": final_result or final_error or "no output",
+                "status": "error" if (task.status == TaskStatus.FAILED or final_error) else "success",
+            })
+
+        # Update the thinking message in-place (no extra new message).
         if thinking_name:
             await self.update_message(thinking_name, reply_text)
         else:

--- a/g3lobster/main.py
+++ b/g3lobster/main.py
@@ -14,6 +14,7 @@ import uvicorn
 
 from g3lobster.agents.registry import AgentRegistry
 from g3lobster.alerts import AlertManager
+from g3lobster.api.event_bus import EventBus
 from g3lobster.api.server import create_app
 from g3lobster.chat.bridge import ChatBridge
 from g3lobster.chat.bridge_manager import BridgeManager
@@ -188,6 +189,7 @@ def build_runtime(config: AppConfig):
         gemini_timeout_s=config.gemini.response_timeout_s or 45.0,
         gemini_cwd=config.gemini.workspace_dir,
     ) if config.cron.enabled else None
+    event_bus = EventBus()
 
     # Standup conductor — must be created before chat_bridge_factory so it can be captured.
     standup_store = StandupStore(config.agents.data_dir)
@@ -224,6 +226,7 @@ def build_runtime(config: AppConfig):
             agent_filter=agent_filter,
             concierge_agent_id=concierge_id,
             debounce_window_ms=config.chat.debounce_window_ms,
+            event_bus=event_bus,
         )
 
     bridge_manager = BridgeManager(
@@ -296,6 +299,7 @@ def build_runtime(config: AppConfig):
         control_plane,
         standup_store,
         standup_orchestrator,
+        event_bus,
     )
 
 
@@ -315,6 +319,7 @@ def build_app(config_path: Optional[str] = None):
         control_plane,
         standup_store,
         standup_orchestrator,
+        event_bus,
     ) = build_runtime(config)
     app = create_app(
         registry=registry,
@@ -331,6 +336,7 @@ def build_app(config_path: Optional[str] = None):
         control_plane=control_plane,
         standup_store=standup_store,
         standup_orchestrator=standup_orchestrator,
+        event_bus=event_bus,
     )
     return app, config
 

--- a/g3lobster/static/css/zen.css
+++ b/g3lobster/static/css/zen.css
@@ -744,6 +744,177 @@ pre.transcript {
   border-top: 1px solid var(--md-sys-color-outline);
 }
 
+/* --- Live Thinking Panel --- */
+
+.thinking-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-3) var(--space-4);
+  background: rgba(14, 22, 27, 0.92);
+  border-radius: var(--radius) var(--radius) 0 0;
+  color: #eaf1f3;
+}
+
+.thinking-title {
+  font-family: "IBM Plex Mono", Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.thinking-connection-pill {
+  font-size: 0.7rem;
+}
+
+.thinking-stream {
+  min-height: 200px;
+  max-height: 520px;
+  overflow-y: auto;
+  padding: var(--space-3);
+  background: rgba(14, 22, 27, 0.96);
+  color: #d4dde2;
+  font-family: "IBM Plex Mono", Menlo, Consolas, monospace;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  border-radius: 0 0 var(--radius) var(--radius);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.thinking-stream .empty {
+  color: #5f6b74;
+  text-align: center;
+  padding: var(--space-8);
+}
+
+.thinking-divider {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin: var(--space-3) 0 var(--space-2);
+  color: #7a8a94;
+  font-size: 0.76rem;
+}
+
+.thinking-divider hr {
+  flex: 1;
+  border: none;
+  border-top: 1px solid rgba(255, 255, 255, 0.12);
+}
+
+.thinking-divider span {
+  white-space: nowrap;
+}
+
+.thinking-block {
+  padding: var(--space-2) var(--space-3);
+  border-radius: 8px;
+  word-break: break-word;
+}
+
+.thinking-label {
+  display: inline-block;
+  font-size: 0.72rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  margin-right: var(--space-2);
+  opacity: 0.7;
+}
+
+.thinking-user {
+  background: rgba(15, 118, 110, 0.18);
+  color: #b2e0db;
+}
+
+.thinking-user .thinking-label {
+  color: #4dd4c0;
+}
+
+.thinking-thought {
+  background: rgba(124, 58, 237, 0.14);
+  color: #c8b4e8;
+}
+
+.thinking-thought .thinking-label {
+  color: #a78bfa;
+}
+
+.thinking-tool {
+  background: rgba(181, 71, 8, 0.14);
+  color: #e0b89a;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.thinking-tool .thinking-label {
+  color: #e8975a;
+}
+
+.tool-name {
+  font-weight: 600;
+}
+
+.thinking-status {
+  margin-left: auto;
+  font-size: 0.72rem;
+}
+
+.breathing-dot::before {
+  content: "";
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #e8975a;
+  margin-right: 4px;
+  animation: breathe 1.4s ease-in-out infinite;
+}
+
+@keyframes breathe {
+  0%, 100% { opacity: 0.3; transform: scale(0.85); }
+  50% { opacity: 1; transform: scale(1.15); }
+}
+
+.done-check::before {
+  content: "\2713";
+  margin-right: 4px;
+  color: #4dd4c0;
+}
+
+.thinking-tool.done {
+  opacity: 0.7;
+}
+
+.thinking-response {
+  background: rgba(6, 118, 71, 0.14);
+  color: #b2e0c8;
+}
+
+.thinking-response .thinking-label {
+  color: #4dd4c0;
+}
+
+.thinking-response-body {
+  margin-top: var(--space-1);
+}
+
+.thinking-response-body p { margin: 0 0 0.4em; }
+.thinking-response-body p:last-child { margin: 0; }
+
+.thinking-error {
+  background: rgba(180, 35, 24, 0.18);
+  color: #e8a09a;
+}
+
+.thinking-error .thinking-label {
+  color: #f87171;
+}
+
 @media (max-width: 860px) {
   .shell {
     padding: var(--space-6) var(--space-4) var(--space-7);

--- a/g3lobster/static/js/agents.js
+++ b/g3lobster/static/js/agents.js
@@ -554,7 +554,147 @@ export async function render(root, { onSetupChange }) {
     `;
   }
 
+  // --- Live Thinking ---
+  let thinkingEventSource = null;
+  let thinkingAgentId = null;
+  const thinkingEvents = {};
+
+  function destroyThinkingStream() {
+    if (thinkingEventSource) {
+      thinkingEventSource.close();
+      thinkingEventSource = null;
+      thinkingAgentId = null;
+    }
+  }
+
+  function connectThinkingStream(agentId) {
+    if (thinkingAgentId === agentId && thinkingEventSource) {
+      return;
+    }
+    destroyThinkingStream();
+    thinkingAgentId = agentId;
+    if (!thinkingEvents[agentId]) {
+      thinkingEvents[agentId] = [];
+    }
+
+    const es = new EventSource(`/agents/${encodeURIComponent(agentId)}/stream`);
+    thinkingEventSource = es;
+
+    es.onmessage = (msg) => {
+      try {
+        const event = JSON.parse(msg.data);
+        thinkingEvents[agentId].push(event);
+        // Keep max 200 events
+        if (thinkingEvents[agentId].length > 200) {
+          thinkingEvents[agentId] = thinkingEvents[agentId].slice(-150);
+        }
+        appendThinkingEvent(event);
+      } catch (_err) {
+        // ignore parse errors
+      }
+    };
+
+    es.onerror = () => {
+      updateConnectionPill(false);
+    };
+
+    es.onopen = () => {
+      updateConnectionPill(true);
+    };
+  }
+
+  function updateConnectionPill(connected) {
+    const pill = root.querySelector(".thinking-connection-pill");
+    if (pill) {
+      pill.textContent = connected ? "connected" : "disconnected";
+      pill.className = `thinking-connection-pill status-pill ${connected ? "ok" : "error"}`;
+    }
+  }
+
+  function renderThinkingEventHtml(event) {
+    const type = event.type || "unknown";
+    if (type === "user_input") {
+      const sender = escapeHtml(event.sender || "user");
+      const text = escapeHtml(event.text || "");
+      return `<div class="thinking-divider"><hr /><span>new message from ${sender}</span></div>
+              <div class="thinking-block thinking-user"><span class="thinking-label">user</span> ${text}</div>`;
+    }
+    if (type === "message") {
+      const content = escapeHtml(event.text || event.data?.content || "");
+      if (!content) return "";
+      return `<div class="thinking-block thinking-thought"><span class="thinking-label">thinking</span> ${content}</div>`;
+    }
+    if (type === "tool_use") {
+      const toolName = escapeHtml(event.data?.tool_name || event.data?.toolName || event.data?.name || "tool");
+      return `<div class="thinking-block thinking-tool"><span class="thinking-label">tool</span> <span class="tool-name">${toolName}</span> <span class="thinking-status breathing-dot">running</span></div>`;
+    }
+    if (type === "tool_result") {
+      const toolName = escapeHtml(event.data?.tool_name || event.data?.toolName || event.data?.name || "tool");
+      return `<div class="thinking-block thinking-tool done"><span class="thinking-label">tool</span> <span class="tool-name">${toolName}</span> <span class="thinking-status done-check">done</span></div>`;
+    }
+    if (type === "response") {
+      const text = event.text || "";
+      const rendered = typeof window.marked !== "undefined" && typeof window.DOMPurify !== "undefined"
+        ? window.DOMPurify.sanitize(window.marked.parse(String(text)))
+        : `<p>${escapeHtml(text)}</p>`;
+      return `<div class="thinking-block thinking-response"><span class="thinking-label">response</span> <div class="thinking-response-body">${rendered}</div></div>`;
+    }
+    if (type === "error") {
+      const msg = escapeHtml(event.data?.message || event.text || "error");
+      return `<div class="thinking-block thinking-error"><span class="thinking-label">error</span> ${msg}</div>`;
+    }
+    return "";
+  }
+
+  function appendThinkingEvent(event) {
+    const container = root.querySelector(".thinking-stream");
+    if (!container) return;
+    const html = renderThinkingEventHtml(event);
+    if (!html) return;
+
+    // If this is a tool_result, try to update the last matching tool_use block
+    if (event.type === "tool_result") {
+      const toolBlocks = container.querySelectorAll(".thinking-tool:not(.done)");
+      if (toolBlocks.length > 0) {
+        const last = toolBlocks[toolBlocks.length - 1];
+        last.classList.add("done");
+        const statusEl = last.querySelector(".thinking-status");
+        if (statusEl) {
+          statusEl.className = "thinking-status done-check";
+          statusEl.textContent = "done";
+        }
+        return;
+      }
+    }
+
+    const div = document.createElement("div");
+    div.innerHTML = html;
+    while (div.firstChild) {
+      container.appendChild(div.firstChild);
+    }
+    container.scrollTop = container.scrollHeight;
+  }
+
+  function thinkingTabMarkup(agent) {
+    const events = thinkingEvents[agent.id] || [];
+    const eventsHtml = events.map(renderThinkingEventHtml).filter(Boolean).join("");
+
+    return `
+      <div class="thinking-panel-header">
+        <span class="thinking-title">LIVE THINKING: ${escapeHtml(agent.name)}</span>
+        <span class="thinking-connection-pill status-pill ok">connected</span>
+      </div>
+      <div class="thinking-stream">${eventsHtml || '<p class="empty">Waiting for events...</p>'}</div>
+      <div class="actions">
+        <button class="btn btn-secondary" data-action="clear-thinking" data-agent-id="${escapeHtml(agent.id)}">Clear</button>
+      </div>
+    `;
+  }
+
   function tabPanelMarkup(agent, detail) {
+    if (activeTab === "thinking") {
+      return thinkingTabMarkup(agent);
+    }
     if (activeTab === "memory") {
       return memoryTabMarkup(agent);
     }
@@ -704,6 +844,7 @@ export async function render(root, { onSetupChange }) {
               <div class="step-panel">
                 <div class="agent-tabs">
                   ${tabButtonMarkup("persona", activeTab, "Persona")}
+                  ${tabButtonMarkup("thinking", activeTab, "Live Thinking")}
                   ${tabButtonMarkup("memory", activeTab, "Memory")}
                   ${tabButtonMarkup("procedures", activeTab, "Procedures")}
                   ${tabButtonMarkup("sessions", activeTab, "Sessions")}
@@ -759,6 +900,16 @@ export async function render(root, { onSetupChange }) {
       }
       queueRerender();
     });
+
+    // Connect SSE stream when Live Thinking tab is active
+    if (activeTab === "thinking" && activeAgent) {
+      connectThinkingStream(activeAgent.id);
+      // Scroll to bottom after render
+      const stream = root.querySelector(".thinking-stream");
+      if (stream) stream.scrollTop = stream.scrollHeight;
+    } else {
+      destroyThinkingStream();
+    }
 
     for (const tabButton of root.querySelectorAll("button[data-tab]")) {
       tabButton.addEventListener("click", () => {
@@ -915,6 +1066,9 @@ export async function render(root, { onSetupChange }) {
             await deleteCronTask(agentId, taskId);
             cronsCache[agentId] = await listCronTasks(agentId);
             setNotice("info", "Cron task deleted.");
+          } else if (action === "clear-thinking") {
+            thinkingEvents[agentId] = [];
+            setNotice("info", "Cleared thinking events.");
           } else if (action === "link-bot") {
             const input = formFieldForAgent(root, agentId, "bot_user_id");
             const botUserId = input?.value?.trim();
@@ -1070,6 +1224,7 @@ export async function render(root, { onSetupChange }) {
         window.clearInterval(metricsIntervalId);
         metricsIntervalId = null;
       }
+      destroyThinkingStream();
     },
   };
 }


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #85.

Adds a real-time "Live Thinking" panel to the web console that streams agent reasoning events via SSE as Google Chat messages are processed. Observers (demo audiences, developers debugging) can watch tool calls, thinking, and responses without needing Google Chat open.

## Changes
- **`g3lobster/api/event_bus.py`** — New lightweight pub/sub EventBus using `asyncio.Queue` per subscriber, keyed by agent_id
- **`g3lobster/api/routes_thinking.py`** — New `GET /agents/{agent_id}/stream` SSE endpoint with 15s heartbeat keep-alive
- **`g3lobster/chat/bridge.py`** — Emit `user_input`, streaming (message/tool_use/tool_result/error/result), and `response` events to the EventBus during `handle_message()`
- **`g3lobster/api/server.py`** — Register thinking router, wire EventBus to app state
- **`g3lobster/main.py`** — Create shared EventBus in `build_runtime()`, pass to ChatBridge factory and `create_app()`
- **`g3lobster/static/js/agents.js`** — New "Live Thinking" tab with EventSource subscription, progressive rendering of SystemDivider, ThinkingBlock, ToolBlock, AgentMessage events, connection status indicator, and clear button
- **`g3lobster/static/css/zen.css`** — Terminal-style thinking panel with color-coded event blocks (violet thinking, orange tools, teal responses), breathing-dot animation for running tools, connection status pill

## Verification
- `make lint`: passing
- `make test`: non-API tests passing (API test collection errors are pre-existing due to missing python-multipart)

Closes #85