### PR TITLE
feat: Google Chat message debouncer for rapid-fire messages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ chat:
   space_id: spaces/AAQAuxoTw1w
   space_name: my-space
   poll_interval_s: 2
+  debounce_window_ms: 2000
 server:
   host: 0.0.0.0
   port: 40000

--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -13,7 +13,8 @@ if TYPE_CHECKING:
     from g3lobster.cron.store import CronStore
 
 from g3lobster.chat.auth import get_authenticated_service
-from g3lobster.chat.commands import handle as handle_command
+from g3lobster.chat.commands import detect_command, handle as handle_command
+from g3lobster.chat.debounce import MessageDebouncer
 from g3lobster.cli.parser import get_content_id
 from g3lobster.cli.streaming import StreamEventType, accumulate_text
 from g3lobster.tasks.types import Task, TaskStatus
@@ -81,6 +82,7 @@ class ChatBridge:
         seen_content_max_size: int = 10_000,
         debug_mode: bool = False,
         agent_filter: Optional[Set[str]] = None,
+        debounce_window_ms: int = 2000,
     ):
         self.registry = registry
         self.poll_interval_s = poll_interval_s
@@ -97,6 +99,10 @@ class ChatBridge:
         self._last_message_time: Optional[str] = last_message_time
         self._seen_content: BoundedSet = BoundedSet(seen_content_max_size)
         self._agent_filter: Optional[Set[str]] = set(agent_filter) if agent_filter is not None else None
+        self._debouncer = MessageDebouncer(
+            window_s=debounce_window_ms / 1000.0,
+            flush_callback=self._dispatch_to_agent,
+        )
         if seen_content:
             for item in seen_content:
                 self._seen_content.add(item)
@@ -125,6 +131,7 @@ class ChatBridge:
 
     async def stop(self) -> None:
         self._stop_event.set()
+        self._debouncer.cancel_all()
         if self._poll_task:
             self._poll_task.cancel()
             try:
@@ -269,28 +276,54 @@ class ChatBridge:
 
         thread_id = message.get("thread", {}).get("name")
         user_id = sender.get("name") or "unknown"
+
+        # Slash-command interception — handle immediately, bypassing debounce.
+        if detect_command(text) is not None:
+            if self.cron_store is not None:
+                cmd_reply = handle_command(text, target_id, self.cron_store)
+                if cmd_reply is not None:
+                    await self.send_message(
+                        f"{persona.emoji} {persona.name}: {cmd_reply}",
+                        thread_id=thread_id,
+                    )
+                    return
+
+        # Route through debouncer — messages are merged until the window expires.
+        key = (self.space_id or "", user_id, thread_id or "")
+        self._debouncer.add(key, message, text, target_id, thread_id or "")
+
+    async def _dispatch_to_agent(
+        self,
+        merged_text: str,
+        first_message: dict,
+        persona_id: str,
+        thread_id: str,
+    ) -> None:
+        """Called by the debouncer on flush — sends the merged prompt to the agent."""
+        runtime = self.registry.get_agent(persona_id)
+        if not runtime:
+            started = await self.registry.start_agent(persona_id)
+            if not started:
+                return
+            runtime = self.registry.get_agent(persona_id)
+            if not runtime:
+                return
+
+        persona = runtime.persona
+        sender = first_message.get("sender", {})
+        user_id = sender.get("name") or "unknown"
         thread_id_safe = (thread_id or "no-thread").replace("/", "_")
         session_id = f"{self.space_id}__{user_id}__{thread_id_safe}"
 
-        # Slash-command interception — handle locally without hitting the AI.
-        if self.cron_store is not None:
-            cmd_reply = handle_command(text, target_id, self.cron_store)
-            if cmd_reply is not None:
-                await self.send_message(
-                    f"{persona.emoji} {persona.name}: {cmd_reply}",
-                    thread_id=thread_id,
-                )
-                return
-
         task = Task(
-            prompt=text,
+            prompt=merged_text,
             session_id=session_id,
             timeout_s=_resolve_task_timeout_s(persona, self.registry),
         )
 
         thinking_msg = await self.send_message(
             f"{persona.emoji} _{persona.name} is thinking..._",
-            thread_id=thread_id,
+            thread_id=thread_id or None,
         )
         thinking_name: Optional[str] = thinking_msg.get("name") if thinking_msg else None
         last_progress_text = f"{persona.emoji} _{persona.name} is thinking..._"
@@ -340,7 +373,7 @@ class ChatBridge:
         if thinking_name:
             await self.update_message(thinking_name, reply_text)
         else:
-            await self.send_message(reply_text, thread_id=thread_id)
+            await self.send_message(reply_text, thread_id=thread_id or None)
 
     async def send_message(self, text: str, thread_id: Optional[str] = None) -> dict:
         body = {"text": text}

--- a/g3lobster/chat/debounce.py
+++ b/g3lobster/chat/debounce.py
@@ -1,0 +1,136 @@
+"""Message debouncer for rapid-fire Google Chat messages.
+
+Collects messages from the same (space, user, thread) tuple within a
+configurable window and flushes them as a single merged prompt.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine, Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Key: (space_id, user_id, thread_id)
+DebounceKey = Tuple[str, str, str]
+
+# Maximum buffered messages per key to prevent unbounded memory growth.
+_MAX_BUFFER_SIZE = 50
+
+
+@dataclass
+class _PendingBurst:
+    """Accumulates messages for a single debounce key."""
+
+    texts: List[str] = field(default_factory=list)
+    first_message: Dict[str, Any] = field(default_factory=dict)
+    persona_id: str = ""
+    thread_id: str = ""
+    timer: asyncio.TimerHandle | None = None
+
+
+class MessageDebouncer:
+    """Buffers rapid-fire messages and flushes them as a merged prompt.
+
+    Parameters
+    ----------
+    window_s:
+        Debounce window in seconds.  Messages arriving within this window
+        after the *last* message are merged.
+    flush_callback:
+        Async callable invoked on flush with ``(merged_text, first_message,
+        persona_id, thread_id)``.
+    """
+
+    def __init__(
+        self,
+        window_s: float = 2.0,
+        flush_callback: Callable[..., Coroutine[Any, Any, None]] | None = None,
+    ) -> None:
+        self._window_s = window_s
+        self._flush_callback = flush_callback
+        self._pending: Dict[DebounceKey, _PendingBurst] = {}
+        self._loop: asyncio.AbstractEventLoop | None = None
+
+    def _get_loop(self) -> asyncio.AbstractEventLoop:
+        if self._loop is None or self._loop.is_closed():
+            self._loop = asyncio.get_running_loop()
+        return self._loop
+
+    def add(
+        self,
+        key: DebounceKey,
+        message: Dict[str, Any],
+        text: str,
+        persona_id: str,
+        thread_id: str,
+    ) -> None:
+        """Buffer a message.  Resets the flush timer on every call."""
+        burst = self._pending.get(key)
+        if burst is None:
+            burst = _PendingBurst(
+                first_message=message,
+                persona_id=persona_id,
+                thread_id=thread_id,
+            )
+            self._pending[key] = burst
+
+        # Enforce bounded buffer.
+        if len(burst.texts) < _MAX_BUFFER_SIZE:
+            burst.texts.append(text)
+
+        # Reset timer on each new message.
+        if burst.timer is not None:
+            burst.timer.cancel()
+
+        loop = self._get_loop()
+        burst.timer = loop.call_later(self._window_s, self._schedule_flush, key)
+
+    def _schedule_flush(self, key: DebounceKey) -> None:
+        """Schedule the async flush from within the event loop callback."""
+        loop = self._get_loop()
+        loop.create_task(self._flush(key))
+
+    async def _flush(self, key: DebounceKey) -> None:
+        burst = self._pending.pop(key, None)
+        if burst is None:
+            return
+
+        merged_text = "\n".join(burst.texts)
+        count = len(burst.texts)
+        logger.info(
+            "Debounce flush: key=%s messages=%d merged_len=%d",
+            key,
+            count,
+            len(merged_text),
+        )
+
+        if self._flush_callback is not None:
+            try:
+                await self._flush_callback(
+                    merged_text,
+                    burst.first_message,
+                    burst.persona_id,
+                    burst.thread_id,
+                )
+            except Exception:
+                logger.exception("Debounce flush callback error for key=%s", key)
+
+    def cancel(self, key: DebounceKey) -> None:
+        """Cancel a pending burst for *key* without flushing."""
+        burst = self._pending.pop(key, None)
+        if burst and burst.timer is not None:
+            burst.timer.cancel()
+
+    def cancel_all(self) -> None:
+        """Cancel all pending bursts.  Call on bridge shutdown."""
+        for burst in self._pending.values():
+            if burst.timer is not None:
+                burst.timer.cancel()
+        self._pending.clear()
+
+    @property
+    def pending_count(self) -> int:
+        return len(self._pending)

--- a/g3lobster/config.py
+++ b/g3lobster/config.py
@@ -52,6 +52,7 @@ class ChatConfig:
     space_id: Optional[str] = None
     space_name: Optional[str] = None
     poll_interval_s: float = 2.0
+    debounce_window_ms: int = 2000
 
 
 @dataclass

--- a/g3lobster/main.py
+++ b/g3lobster/main.py
@@ -192,6 +192,7 @@ def build_runtime(config: AppConfig):
             cron_store=cron_store,
             debug_mode=config.debug_mode,
             agent_filter=agent_filter,
+            debounce_window_ms=config.chat.debounce_window_ms,
         )
 
     bridge_manager = BridgeManager(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from g3lobster.agents.persona import AgentPersona, save_persona
@@ -158,6 +160,7 @@ async def test_chat_bridge_routes_to_named_agent_by_bot_user_id(tmp_path) -> Non
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -173,6 +176,7 @@ async def test_chat_bridge_routes_to_named_agent_by_bot_user_id(tmp_path) -> Non
     }
 
     await bridge.handle_message(message)
+    await asyncio.sleep(0.05)  # allow debounce flush
 
     assert len(service.messages_api.created) == 1
     assert service.messages_api.created[0]["body"]["text"] == "🦀 _Luna is thinking..._"
@@ -215,6 +219,7 @@ async def test_chat_bridge_session_key_is_space_and_user(tmp_path) -> None:
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     base_message = {
@@ -232,7 +237,9 @@ async def test_chat_bridge_session_key_is_space_and_user(tmp_path) -> None:
     msg2 = {**base_message, "text": "Hello from thread B", "thread": {"name": "spaces/test/threads/bbb"}}
 
     await bridge.handle_message(msg1)
+    await asyncio.sleep(0.05)  # allow debounce flush
     await bridge.handle_message(msg2)
+    await asyncio.sleep(0.05)  # allow debounce flush
 
     assert len(captured_session_ids) == 2
     assert captured_session_ids[0] != captured_session_ids[1]
@@ -266,6 +273,7 @@ async def test_chat_bridge_ignores_unlinked_mentions(tmp_path) -> None:
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -281,6 +289,7 @@ async def test_chat_bridge_ignores_unlinked_mentions(tmp_path) -> None:
     }
 
     await bridge.handle_message(message)
+    await asyncio.sleep(0.05)  # allow debounce flush
 
     assert service.messages_api.created == []
 
@@ -310,6 +319,7 @@ async def test_debug_mode_shows_error_detail_in_chat(tmp_path) -> None:
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
         debug_mode=True,
     )
 
@@ -326,6 +336,7 @@ async def test_debug_mode_shows_error_detail_in_chat(tmp_path) -> None:
     }
 
     await bridge.handle_message(message)
+    await asyncio.sleep(0.05)  # allow debounce flush
 
     assert len(service.messages_api.updated) == 1
     updated_text = service.messages_api.updated[0]["body"]["text"]
@@ -359,6 +370,7 @@ async def test_debug_off_hides_error_code_block(tmp_path) -> None:
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
         debug_mode=False,
     )
 
@@ -375,6 +387,7 @@ async def test_debug_off_hides_error_code_block(tmp_path) -> None:
     }
 
     await bridge.handle_message(message)
+    await asyncio.sleep(0.05)  # allow debounce flush
 
     assert len(service.messages_api.updated) == 1
     updated_text = service.messages_api.updated[0]["body"]["text"]
@@ -407,6 +420,7 @@ async def test_chat_bridge_updates_original_message_for_tool_use(tmp_path) -> No
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -422,6 +436,7 @@ async def test_chat_bridge_updates_original_message_for_tool_use(tmp_path) -> No
     }
 
     await bridge.handle_message(message)
+    await asyncio.sleep(0.05)  # allow debounce flush
 
     assert len(service.messages_api.created) == 1
     assert service.messages_api.created[0]["body"]["text"] == "🦀 _Luna is thinking..._"
@@ -476,6 +491,7 @@ async def test_chat_bridge_uses_task_error_when_stream_ends_silently(tmp_path) -
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -491,6 +507,7 @@ async def test_chat_bridge_uses_task_error_when_stream_ends_silently(tmp_path) -
     }
 
     await bridge.handle_message(message)
+    await asyncio.sleep(0.05)  # allow debounce flush
 
     assert len(service.messages_api.created) == 1
     assert len(service.messages_api.updated) == 1

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -1,0 +1,170 @@
+"""Tests for g3lobster.chat.debounce.MessageDebouncer."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from g3lobster.chat.debounce import MessageDebouncer
+
+
+def _make_message(user_id: str = "users/1", thread: str = "threads/a") -> dict:
+    return {
+        "sender": {"type": "HUMAN", "name": user_id},
+        "thread": {"name": thread},
+        "text": "hello",
+    }
+
+
+KEY = ("spaces/test", "users/1", "threads/a")
+
+
+@pytest.mark.asyncio
+async def test_single_message_passthrough() -> None:
+    """A single message should flush after the debounce window."""
+    flushed: list[tuple[str, dict, str, str]] = []
+
+    async def on_flush(text, msg, persona_id, thread_id):
+        flushed.append((text, msg, persona_id, thread_id))
+
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=on_flush)
+    msg = _make_message()
+    debouncer.add(KEY, msg, "hello", "luna", "threads/a")
+
+    # Wait for flush
+    await asyncio.sleep(0.15)
+
+    assert len(flushed) == 1
+    assert flushed[0][0] == "hello"
+    assert flushed[0][2] == "luna"
+    assert flushed[0][3] == "threads/a"
+
+
+@pytest.mark.asyncio
+async def test_multi_message_merge() -> None:
+    """Multiple rapid messages should merge into a single flush."""
+    flushed: list[tuple[str, dict, str, str]] = []
+
+    async def on_flush(text, msg, persona_id, thread_id):
+        flushed.append((text, msg, persona_id, thread_id))
+
+    debouncer = MessageDebouncer(window_s=0.1, flush_callback=on_flush)
+    msg = _make_message()
+
+    debouncer.add(KEY, msg, "line 1", "luna", "threads/a")
+    debouncer.add(KEY, msg, "line 2", "luna", "threads/a")
+    debouncer.add(KEY, msg, "line 3", "luna", "threads/a")
+
+    # Wait for flush
+    await asyncio.sleep(0.25)
+
+    assert len(flushed) == 1
+    assert flushed[0][0] == "line 1\nline 2\nline 3"
+
+
+@pytest.mark.asyncio
+async def test_timer_reset_on_new_message() -> None:
+    """Adding a message resets the timer — flush only happens after the last message + window."""
+    flushed: list[str] = []
+
+    async def on_flush(text, msg, persona_id, thread_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.1, flush_callback=on_flush)
+    msg = _make_message()
+
+    debouncer.add(KEY, msg, "first", "luna", "threads/a")
+    await asyncio.sleep(0.06)  # within window — no flush yet
+    assert len(flushed) == 0
+
+    debouncer.add(KEY, msg, "second", "luna", "threads/a")
+    await asyncio.sleep(0.06)  # timer reset — still within new window
+    assert len(flushed) == 0
+
+    await asyncio.sleep(0.15)  # now past the window
+    assert len(flushed) == 1
+    assert flushed[0] == "first\nsecond"
+
+
+@pytest.mark.asyncio
+async def test_different_keys_flush_independently() -> None:
+    """Messages from different keys flush independently."""
+    flushed: list[tuple[str, str]] = []
+
+    async def on_flush(text, msg, persona_id, thread_id):
+        flushed.append((text, thread_id))
+
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=on_flush)
+    msg = _make_message()
+
+    key_a = ("spaces/test", "users/1", "threads/a")
+    key_b = ("spaces/test", "users/2", "threads/b")
+
+    debouncer.add(key_a, msg, "msg A", "luna", "threads/a")
+    debouncer.add(key_b, msg, "msg B", "luna", "threads/b")
+
+    await asyncio.sleep(0.15)
+
+    assert len(flushed) == 2
+    texts = {f[0] for f in flushed}
+    assert texts == {"msg A", "msg B"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_prevents_flush() -> None:
+    """Cancelling a key should prevent the flush callback."""
+    flushed: list[str] = []
+
+    async def on_flush(text, msg, persona_id, thread_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=on_flush)
+    msg = _make_message()
+
+    debouncer.add(KEY, msg, "will cancel", "luna", "threads/a")
+    debouncer.cancel(KEY)
+
+    await asyncio.sleep(0.15)
+    assert len(flushed) == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_prevents_all_flushes() -> None:
+    """cancel_all should prevent all pending flushes."""
+    flushed: list[str] = []
+
+    async def on_flush(text, msg, persona_id, thread_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=on_flush)
+    msg = _make_message()
+
+    key_a = ("spaces/test", "users/1", "threads/a")
+    key_b = ("spaces/test", "users/2", "threads/b")
+
+    debouncer.add(key_a, msg, "msg A", "luna", "threads/a")
+    debouncer.add(key_b, msg, "msg B", "luna", "threads/b")
+    debouncer.cancel_all()
+
+    await asyncio.sleep(0.15)
+    assert len(flushed) == 0
+    assert debouncer.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_configurable_window() -> None:
+    """The debounce window should be configurable."""
+    flushed: list[str] = []
+
+    async def on_flush(text, msg, persona_id, thread_id):
+        flushed.append(text)
+
+    # Very short window
+    debouncer = MessageDebouncer(window_s=0.02, flush_callback=on_flush)
+    msg = _make_message()
+    debouncer.add(KEY, msg, "quick", "luna", "threads/a")
+
+    await asyncio.sleep(0.08)
+    assert len(flushed) == 1
+    assert flushed[0] == "quick"

--- a/tests/test_timeout_policy.py
+++ b/tests/test_timeout_policy.py
@@ -256,6 +256,7 @@ async def test_chat_bridge_uses_persona_response_timeout(tmp_path: Path) -> None
         space_id="spaces/test",
         service=_FakeService(),
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -271,6 +272,7 @@ async def test_chat_bridge_uses_persona_response_timeout(tmp_path: Path) -> None
     }
 
     await bridge.handle_message(message)
+    await asyncio.sleep(0.05)
     assert runtime.captured_timeout == 0.0
 
 
@@ -294,6 +296,7 @@ async def test_chat_bridge_falls_back_to_registry_timeout(tmp_path: Path) -> Non
         space_id="spaces/test",
         service=_FakeService(),
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -309,6 +312,7 @@ async def test_chat_bridge_falls_back_to_registry_timeout(tmp_path: Path) -> Non
     }
 
     await bridge.handle_message(message)
+    await asyncio.sleep(0.05)
     assert runtime.captured_timeout == 42.0
 
 


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #70.

Adds a `MessageDebouncer` that collects rapid-fire messages from the same user+thread within a configurable window (default 2s) and flushes them as a single merged prompt. This eliminates redundant Gemini CLI invocations, interleaved responses, and API rate-limit contention when users type in send-per-thought style.

## Changes
- **`g3lobster/chat/debounce.py` (new)** — `MessageDebouncer` class with asyncio timer-based debouncing, keyed by `(space_id, user_id, thread_id)`, bounded buffer, cancel/cancel_all for cleanup
- **`g3lobster/config.py`** — Added `debounce_window_ms: int = 2000` to `ChatConfig`
- **`config.yaml`** — Added `debounce_window_ms` to chat section
- **`g3lobster/chat/bridge.py`** — Refactored `handle_message()` to check `detect_command()` before debounce (slash commands bypass), route non-command messages through debouncer, extracted `_dispatch_to_agent()` method called on flush, cancel debouncer on stop
- **`g3lobster/main.py`** — Pass `debounce_window_ms` from config to `ChatBridge` via factory
- **`tests/test_debounce.py` (new)** — 7 unit tests: single message passthrough, multi-message merge, timer reset on new message, independent key flush, cancel, cancel_all, configurable window
- **`tests/test_chat.py`, `tests/test_timeout_policy.py`** — Updated existing tests for debounce compatibility

## Verification
- `pytest tests/` — all 32 affected tests passing

Closes #70