### PR TITLE
feat(gammawave): implement #80 — decision log agent

### DIFF
--- a/g3lobster/api/models.py
+++ b/g3lobster/api/models.py
@@ -237,3 +237,16 @@ class AssociationResponse(BaseModel):
     target_id: str
     relation_type: str = "related"
     weight: float = 1.0
+
+
+class DecisionEntryResponse(BaseModel):
+    timestamp: str = ""
+    session_id: str = ""
+    decision: str = ""
+    reasoning: str = ""
+    context: str = ""
+    tags: List[str] = Field(default_factory=list)
+
+
+class DecisionQueryResponse(BaseModel):
+    decisions: List[DecisionEntryResponse] = Field(default_factory=list)

--- a/g3lobster/api/routes_agents.py
+++ b/g3lobster/api/routes_agents.py
@@ -23,6 +23,8 @@ from g3lobster.api.models import (
     AgentResponse,
     AgentUpdateRequest,
     AssociationResponse,
+    DecisionEntryResponse,
+    DecisionQueryResponse,
     JournalCreateRequest,
     JournalEntryResponse,
     JournalQueryRequest,
@@ -775,6 +777,25 @@ async def get_journal_associations(
 
     edges = manager.get_journal_associations(entry_id)
     return [AssociationResponse(**e) for e in edges]
+
+
+@router.get("/{agent_id}/decisions", response_model=DecisionQueryResponse)
+async def query_decisions(
+    agent_id: str,
+    request: Request,
+    q: str = Query(default=""),
+    limit: int = Query(default=20, ge=1, le=200),
+) -> DecisionQueryResponse:
+    config = request.app.state.config
+    _ensure_persona(config.agents.data_dir, agent_id)
+    manager = _memory_manager(request, agent_id)
+    if q:
+        results = manager.query_decisions(q, limit=limit)
+    else:
+        results = manager.list_decisions(limit=limit)
+    return DecisionQueryResponse(
+        decisions=[DecisionEntryResponse(**entry) for entry in results],
+    )
 
 
 @router.post("/{agent_id}/link-bot")

--- a/g3lobster/cli/parser.py
+++ b/g3lobster/cli/parser.py
@@ -49,13 +49,25 @@ def clean_text(text: str, strip_markdown: bool = False) -> str:
     return "\n".join(lines)
 
 
+def split_reasoning(text: str) -> tuple[str, str]:
+    """Split model output into (reasoning, response).
+
+    Returns a tuple where the first element is the reasoning/thinking
+    text (before the separator) and the second is the actual response.
+    If no separator is found, reasoning is empty.
+    """
+    if not text:
+        return ("", "")
+    if "✦" in text:
+        parts = text.split("✦", 1)
+        return (parts[0].strip(), parts[1].strip())
+    return ("", text.strip())
+
+
 def strip_reasoning(text: str) -> str:
     """Heuristic to strip reasoning/thinking from model responses."""
-    if not text:
-        return ""
-    if "✦" in text:
-        return text.split("✦", 1)[1].strip()
-    return text.strip()
+    _, response = split_reasoning(text)
+    return response
 
 
 def get_content_id(content: str) -> str:

--- a/g3lobster/memory/compactor.py
+++ b/g3lobster/memory/compactor.py
@@ -10,6 +10,7 @@ import subprocess
 import threading
 from typing import Callable, Dict, List, Optional
 
+from g3lobster.memory.decisions import DecisionLog, looks_like_decision
 from g3lobster.memory.procedures import CandidateStore, ProcedureStore
 from g3lobster.memory.sessions import SessionStore
 
@@ -33,10 +34,12 @@ class CompactionEngine:
         gemini_args: Optional[List[str]] = None,
         gemini_timeout_s: float = 45.0,
         gemini_cwd: Optional[str] = None,
+        decision_log: Optional[DecisionLog] = None,
     ):
         self.session_store = session_store
         self.procedure_store = procedure_store
         self.candidate_store = candidate_store
+        self.decision_log = decision_log
         self.compact_threshold = max(1, int(compact_threshold))
         self.compact_keep_ratio = min(0.9, max(0.05, float(compact_keep_ratio)))
         self.compact_chunk_size = max(1, int(compact_chunk_size))
@@ -101,7 +104,39 @@ class CompactionEngine:
             if promoted:
                 self._upsert_procedures_locked(promoted)
 
+        # Extract decisions from compacted messages.
+        self._extract_decisions(session_id, compacted)
+
         return True
+
+    def _extract_decisions(self, session_id: str, messages: List[Dict[str, object]]) -> None:
+        """Scan compacted messages for decision-indicating patterns and log them."""
+        if not self.decision_log:
+            return
+        for entry in messages:
+            message = entry.get("message", {})
+            if not isinstance(message, dict):
+                continue
+            role = str(message.get("role", "")).strip().lower()
+            content = str(message.get("content", "")).strip()
+            if not content or role not in ("assistant", "user"):
+                continue
+            if not looks_like_decision(content):
+                continue
+            reasoning = ""
+            metadata = entry.get("metadata")
+            if isinstance(metadata, dict):
+                reasoning = str(metadata.get("reasoning", ""))
+            try:
+                self.decision_log.append(
+                    session_id=session_id,
+                    decision=content[:500],
+                    context=f"{role} message during session {session_id}",
+                    reasoning=reasoning,
+                    tags=["auto-extracted", "compaction"],
+                )
+            except Exception as exc:
+                logger.warning("Failed to log extracted decision: %s", exc)
 
     def _upsert_procedures_locked(self, procedures: List) -> None:
         """Write to PROCEDURES.md under a lock to prevent concurrent clobber."""

--- a/g3lobster/memory/context.py
+++ b/g3lobster/memory/context.py
@@ -65,6 +65,7 @@ _DISPLAY_ORDER = [
     "user_prefs",
     "knowledge",
     "memory",
+    "decisions",
     "recollection",
     "procedures",
     "compaction",
@@ -112,6 +113,26 @@ class ContextBuilder:
             data_dir=data_dir,
             global_data_dir=global_data_dir,
         )
+
+    def _decisions_layer(self, prompt: str) -> str:
+        """Query the decision log for relevant past decisions."""
+        try:
+            decisions = self.memory_manager.query_decisions(prompt, limit=3)
+        except Exception:
+            return ""
+        if not decisions:
+            return ""
+
+        lines = ["# Relevant Past Decisions"]
+        for decision in decisions:
+            text = str(decision.get("decision", "")).strip()
+            reasoning = str(decision.get("reasoning", "")).strip()
+            ts = str(decision.get("timestamp", ""))[:10]
+            entry = f"- [{ts}] {text[:200]}"
+            if reasoning:
+                entry += f"\n  Reasoning: {reasoning[:200]}"
+            lines.append(entry)
+        return "\n".join(lines)
 
     def _recollection_layer(self) -> str:
         """Return recollection content from the association graph.
@@ -174,6 +195,9 @@ class ContextBuilder:
         # --- recollection stub ---
         recollection_content = self._recollection_layer()
 
+        # --- relevant past decisions ---
+        decisions_content = self._decisions_layer(prompt)
+
         # --- construct layers ---
         layers: List[ContextLayer] = [
             ContextLayer(
@@ -230,18 +254,23 @@ class ContextBuilder:
                 content=agents_content,
             ),
             ContextLayer(
-                name="recollection",
+                name="decisions",
                 priority=8,
+                content=decisions_content,
+            ),
+            ContextLayer(
+                name="recollection",
+                priority=9,
                 content=recollection_content,
             ),
             ContextLayer(
                 name="procedures",
-                priority=9,
+                priority=10,
                 content="# Known Procedures\n" + self._format_procedures(matched),
             ),
             ContextLayer(
                 name="compaction",
-                priority=10,
+                priority=11,
                 content=(
                     "# Compaction Summary\n"
                     + (str(compaction.get("summary", "")).strip() or "(none)")

--- a/g3lobster/memory/decisions.py
+++ b/g3lobster/memory/decisions.py
@@ -1,0 +1,120 @@
+"""Append-only JSONL decision log for agent decision rationale."""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+# Patterns that indicate a decision was made in conversation text.
+_DECISION_PATTERNS = [
+    re.compile(r"\b(?:I decided|I\'ve decided|we decided)\b", re.IGNORECASE),
+    re.compile(r"\b(?:let\'s go with|going with|went with)\b", re.IGNORECASE),
+    re.compile(r"\b(?:the approach is|the plan is|the strategy is)\b", re.IGNORECASE),
+    re.compile(r"\b(?:we chose|I chose|choosing)\b", re.IGNORECASE),
+    re.compile(r"\bbecause\b.*\b(?:better|best|prefer|should|will)\b", re.IGNORECASE),
+    re.compile(r"\b(?:decision|rationale):\s", re.IGNORECASE),
+]
+
+
+def looks_like_decision(text: str) -> bool:
+    """Return True if text contains decision-indicating language."""
+    if not text:
+        return False
+    return any(pattern.search(text) for pattern in _DECISION_PATTERNS)
+
+
+class DecisionLog:
+    """Append-only JSONL storage for decision entries.
+
+    Storage path: ``<base_dir>/decisions.jsonl``
+
+    Each line is a JSON object with keys:
+        timestamp, session_id, decision, reasoning, context, tags
+    """
+
+    def __init__(self, base_dir: str):
+        self.base_dir = Path(base_dir)
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self._path = self.base_dir / "decisions.jsonl"
+        self._lock = threading.Lock()
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def append(
+        self,
+        session_id: str,
+        decision: str,
+        context: str = "",
+        reasoning: str = "",
+        tags: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Append a decision entry and return the stored record."""
+        entry: Dict[str, Any] = {
+            "timestamp": datetime.now(tz=timezone.utc).isoformat(),
+            "session_id": session_id,
+            "decision": decision,
+            "reasoning": reasoning,
+            "context": context,
+            "tags": tags or [],
+        }
+        with self._lock:
+            with self._path.open("a", encoding="utf-8") as handle:
+                handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        return entry
+
+    def _iter_entries(self) -> List[Dict[str, Any]]:
+        """Read all entries from the JSONL file."""
+        entries: List[Dict[str, Any]] = []
+        if not self._path.exists():
+            return entries
+        with self._path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(payload, dict):
+                    entries.append(payload)
+        return entries
+
+    def query(self, query_text: str, limit: int = 10) -> List[Dict[str, Any]]:
+        """Keyword search across decision entries.
+
+        Searches the decision, reasoning, context, and tags fields.
+        Returns most recent matching entries first.
+        """
+        if not query_text or not query_text.strip():
+            return self.list(limit=limit)
+
+        keywords = query_text.lower().split()
+        entries = self._iter_entries()
+        matches: List[Dict[str, Any]] = []
+
+        for entry in reversed(entries):
+            searchable = " ".join([
+                str(entry.get("decision", "")),
+                str(entry.get("reasoning", "")),
+                str(entry.get("context", "")),
+                " ".join(entry.get("tags", [])),
+            ]).lower()
+            if all(kw in searchable for kw in keywords):
+                matches.append(entry)
+                if len(matches) >= limit:
+                    break
+
+        return matches
+
+    def list(self, limit: int = 50) -> List[Dict[str, Any]]:
+        """Return the most recent decisions."""
+        entries = self._iter_entries()
+        return list(reversed(entries[-limit:]))

--- a/g3lobster/memory/manager.py
+++ b/g3lobster/memory/manager.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from g3lobster.memory.compactor import CompactionEngine
+from g3lobster.memory.decisions import DecisionLog
 from g3lobster.memory.journal import (
     AssociationGraph,
     JournalEntry,
@@ -71,6 +72,7 @@ class MemoryManager:
         self.association_graph = AssociationGraph(str(self.memory_dir))
 
         self.sessions = SessionStore(str(self.sessions_dir))
+        self.decision_log = DecisionLog(str(self.memory_dir))
         self.procedure_store = ProcedureStore(
             str(self.procedures_file),
             min_frequency=self.procedure_min_frequency,
@@ -88,6 +90,7 @@ class MemoryManager:
             gemini_args=gemini_args,
             gemini_timeout_s=gemini_timeout_s,
             gemini_cwd=gemini_cwd,
+            decision_log=self.decision_log,
         )
 
     def read_memory(self) -> str:
@@ -256,6 +259,31 @@ class MemoryManager:
     def get_journal_associations(self, entry_id: str) -> List[Dict[str, Any]]:
         edges = self.association_graph.get_associations(entry_id)
         return [e.as_dict() for e in edges]
+
+    def append_decision(
+        self,
+        session_id: str,
+        decision: str,
+        context: str = "",
+        reasoning: str = "",
+        tags: Optional[List[str]] = None,
+    ) -> Dict[str, Any]:
+        """Append a decision to the decision log."""
+        return self.decision_log.append(
+            session_id=session_id,
+            decision=decision,
+            context=context,
+            reasoning=reasoning,
+            tags=tags,
+        )
+
+    def query_decisions(self, query: str = "", limit: int = 10) -> List[Dict[str, Any]]:
+        """Query the decision log with optional keyword search."""
+        return self.decision_log.query(query, limit=limit)
+
+    def list_decisions(self, limit: int = 50) -> List[Dict[str, Any]]:
+        """List recent decisions."""
+        return self.decision_log.list(limit=limit)
 
     def append_message(
         self,

--- a/g3lobster/pool/agent.py
+++ b/g3lobster/pool/agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import time
 from typing import Callable, List, Optional
 
-from g3lobster.cli.parser import clean_text, strip_reasoning
+from g3lobster.cli.parser import clean_text, split_reasoning
 from g3lobster.memory.context import ContextBuilder
 from g3lobster.memory.manager import MemoryManager
 from g3lobster.mcp.manager import MCPManager
@@ -105,12 +105,17 @@ class GeminiAgent:
                 timeout=_normalize_timeout(task.timeout_s),
                 session_id=task.session_id,
             )
-            parsed = strip_reasoning(clean_text(raw_output))
+            reasoning, parsed = split_reasoning(clean_text(raw_output))
             task.result = parsed
             task.status = TaskStatus.COMPLETED
             task.completed_at = time.time()
             task.add_event("completed", {"chars": len(parsed or "")})
-            self.memory_manager.append_message(task.session_id, "assistant", parsed, {"task_id": task.id})
+            if reasoning:
+                task.add_event("reasoning", {"text": reasoning})
+            self.memory_manager.append_message(
+                task.session_id, "assistant", parsed,
+                {"task_id": task.id, "reasoning": reasoning} if reasoning else {"task_id": task.id},
+            )
         except Exception as exc:  # pragma: no cover - defensive path
             if task.status != TaskStatus.CANCELED:
                 task.error = str(exc)
@@ -187,7 +192,8 @@ class GeminiAgent:
                 collected_events.append(event)
                 yield event
 
-            parsed = accumulate_text(collected_events)
+            raw_accumulated = accumulate_text(collected_events)
+            reasoning, parsed = split_reasoning(clean_text(raw_accumulated))
             result_error = None
             stream_error = None
             for event in collected_events:
@@ -211,7 +217,12 @@ class GeminiAgent:
                 task.result = parsed
                 task.status = TaskStatus.COMPLETED
                 task.add_event("completed", {"chars": len(parsed)})
-                self.memory_manager.append_message(task.session_id, "assistant", parsed, {"task_id": task.id})
+                if reasoning:
+                    task.add_event("reasoning", {"text": reasoning})
+                self.memory_manager.append_message(
+                    task.session_id, "assistant", parsed,
+                    {"task_id": task.id, "reasoning": reasoning} if reasoning else {"task_id": task.id},
+                )
         except Exception as exc:
             if task.status != TaskStatus.CANCELED:
                 task.error = str(exc)

--- a/tests/test_decisions.py
+++ b/tests/test_decisions.py
@@ -1,0 +1,205 @@
+"""Tests for the decision log system."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from g3lobster.cli.parser import split_reasoning, strip_reasoning
+from g3lobster.memory.compactor import CompactionEngine
+from g3lobster.memory.decisions import DecisionLog, looks_like_decision
+from g3lobster.memory.sessions import SessionStore
+
+
+# --- split_reasoning tests ---
+
+
+def test_split_reasoning_with_separator() -> None:
+    text = "thinking about options ✦ The answer is 42."
+    reasoning, response = split_reasoning(text)
+    assert reasoning == "thinking about options"
+    assert response == "The answer is 42."
+
+
+def test_split_reasoning_without_separator() -> None:
+    reasoning, response = split_reasoning("just a plain response")
+    assert reasoning == ""
+    assert response == "just a plain response"
+
+
+def test_split_reasoning_empty() -> None:
+    reasoning, response = split_reasoning("")
+    assert reasoning == ""
+    assert response == ""
+
+
+def test_strip_reasoning_still_works() -> None:
+    assert strip_reasoning("thinking ✦ answer") == "answer"
+    assert strip_reasoning("just text") == "just text"
+    assert strip_reasoning("") == ""
+
+
+# --- looks_like_decision tests ---
+
+
+def test_looks_like_decision_positive() -> None:
+    assert looks_like_decision("I decided to use Python for this project")
+    assert looks_like_decision("Let's go with the second approach")
+    assert looks_like_decision("We chose option A because it's better")
+    assert looks_like_decision("The approach is to use microservices")
+    assert looks_like_decision("Decision: use Redis for caching")
+
+
+def test_looks_like_decision_negative() -> None:
+    assert not looks_like_decision("Hello, how are you?")
+    assert not looks_like_decision("The weather is nice today")
+    assert not looks_like_decision("")
+
+
+# --- DecisionLog CRUD tests ---
+
+
+def test_decision_log_append_and_list(tmp_path: Path) -> None:
+    log = DecisionLog(str(tmp_path / "memory"))
+    entry = log.append(
+        session_id="sess-1",
+        decision="Use PostgreSQL over MySQL",
+        context="Database discussion",
+        reasoning="Better JSON support and extensibility",
+        tags=["database", "architecture"],
+    )
+
+    assert entry["session_id"] == "sess-1"
+    assert entry["decision"] == "Use PostgreSQL over MySQL"
+    assert entry["reasoning"] == "Better JSON support and extensibility"
+    assert entry["tags"] == ["database", "architecture"]
+    assert "timestamp" in entry
+
+    items = log.list(limit=10)
+    assert len(items) == 1
+    assert items[0]["decision"] == "Use PostgreSQL over MySQL"
+
+
+def test_decision_log_query(tmp_path: Path) -> None:
+    log = DecisionLog(str(tmp_path / "memory"))
+    log.append(session_id="s1", decision="Use Redis for caching", tags=["infra"])
+    log.append(session_id="s2", decision="Use PostgreSQL for storage", tags=["database"])
+    log.append(session_id="s3", decision="Deploy to AWS", tags=["infra"])
+
+    # Query by keyword
+    results = log.query("Redis", limit=10)
+    assert len(results) == 1
+    assert "Redis" in results[0]["decision"]
+
+    # Query by tag
+    results = log.query("infra", limit=10)
+    assert len(results) == 2
+
+    # Query with multiple keywords
+    results = log.query("PostgreSQL storage", limit=10)
+    assert len(results) == 1
+
+
+def test_decision_log_query_empty(tmp_path: Path) -> None:
+    log = DecisionLog(str(tmp_path / "memory"))
+    results = log.query("anything")
+    assert results == []
+
+
+def test_decision_log_list_most_recent_first(tmp_path: Path) -> None:
+    log = DecisionLog(str(tmp_path / "memory"))
+    log.append(session_id="s1", decision="First decision")
+    log.append(session_id="s2", decision="Second decision")
+    log.append(session_id="s3", decision="Third decision")
+
+    items = log.list(limit=2)
+    assert len(items) == 2
+    assert items[0]["decision"] == "Third decision"
+    assert items[1]["decision"] == "Second decision"
+
+
+def test_decision_log_jsonl_format(tmp_path: Path) -> None:
+    log = DecisionLog(str(tmp_path / "memory"))
+    log.append(session_id="s1", decision="Test decision")
+
+    path = tmp_path / "memory" / "decisions.jsonl"
+    assert path.exists()
+
+    lines = path.read_text().strip().split("\n")
+    assert len(lines) == 1
+    parsed = json.loads(lines[0])
+    assert parsed["decision"] == "Test decision"
+    assert parsed["session_id"] == "s1"
+
+
+def test_decision_log_empty_query_returns_recent(tmp_path: Path) -> None:
+    log = DecisionLog(str(tmp_path / "memory"))
+    log.append(session_id="s1", decision="A decision")
+
+    results = log.query("", limit=10)
+    assert len(results) == 1
+
+
+# --- Decision extraction during compaction ---
+
+
+def test_compaction_extracts_decisions(tmp_path: Path) -> None:
+    """Verify that _extract_decisions logs decision-like messages."""
+    decision_log = DecisionLog(str(tmp_path / "memory"))
+    session_store = SessionStore(str(tmp_path / "sessions"))
+
+    class _ProcedureStore:
+        def upsert_procedures(self, _procedures) -> None:
+            pass
+
+    compactor = CompactionEngine(
+        session_store=session_store,
+        procedure_store=_ProcedureStore(),
+        compact_threshold=100,
+        decision_log=decision_log,
+    )
+
+    messages = [
+        {
+            "type": "message",
+            "message": {"role": "assistant", "content": "I decided to use Redis for caching."},
+        },
+        {
+            "type": "message",
+            "message": {"role": "user", "content": "Sounds good!"},
+        },
+        {
+            "type": "message",
+            "message": {"role": "assistant", "content": "Let's go with the microservice approach."},
+        },
+    ]
+
+    compactor._extract_decisions("test-session", messages)
+
+    decisions = decision_log.list(limit=10)
+    # Should have extracted the two decision-like messages (most recent first)
+    assert len(decisions) == 2
+    assert "microservice" in decisions[0]["decision"]
+    assert "Redis" in decisions[1]["decision"]
+
+
+# --- MemoryManager decision integration ---
+
+
+def test_memory_manager_decision_methods(tmp_path: Path) -> None:
+    from g3lobster.memory.manager import MemoryManager
+
+    manager = MemoryManager(data_dir=str(tmp_path / "agent"))
+    entry = manager.append_decision(
+        session_id="s1",
+        decision="Use FastAPI",
+        reasoning="Async support",
+        tags=["framework"],
+    )
+    assert entry["decision"] == "Use FastAPI"
+
+    results = manager.query_decisions("FastAPI")
+    assert len(results) == 1
+
+    items = manager.list_decisions()
+    assert len(items) == 1

--- a/tests/test_decisions_api.py
+++ b/tests/test_decisions_api.py
@@ -1,0 +1,157 @@
+"""Tests for the GET /agents/{id}/decisions API endpoint."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+import yaml
+from fastapi.testclient import TestClient
+
+from g3lobster.agents.registry import AgentRegistry
+from g3lobster.api.server import create_app
+from g3lobster.chat.bridge_manager import BridgeManager
+from g3lobster.config import AppConfig
+from g3lobster.memory.global_memory import GlobalMemoryManager
+from g3lobster.pool.types import AgentState
+from g3lobster.tasks.types import TaskStatus
+
+
+class FakeAgent:
+    def __init__(self, agent_id: str):
+        self.id = agent_id
+        self.state = AgentState.STARTING
+        self.started_at = time.time()
+        self.current_task = None
+        self.busy_since = None
+        self.mcp_servers = ["*"]
+
+    async def start(self, mcp_servers=None):
+        self.mcp_servers = list(mcp_servers or ["*"])
+        self.state = AgentState.IDLE
+
+    async def stop(self):
+        self.state = AgentState.STOPPED
+
+    def is_alive(self):
+        return self.state != AgentState.STOPPED
+
+    async def assign(self, task):
+        task.status = TaskStatus.COMPLETED
+        task.result = "ok"
+        task.completed_at = time.time()
+        self.state = AgentState.IDLE
+        return task
+
+
+class FakeChatBridge:
+    def __init__(self, **kwargs):
+        self.messages = []
+        self.space_id = kwargs.get("space_id")
+
+    async def send_message(self, msg):
+        self.messages.append(msg)
+
+
+def _build_test_app(tmp_path: Path):
+    data_dir = tmp_path / "data"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(yaml.dump({"version": "1.0"}))
+
+    config = AppConfig()
+    config.agents.data_dir = str(data_dir)
+    config.chat.enabled = False
+    config.chat.space_id = "spaces/test-space"
+
+    registry = AgentRegistry(
+        data_dir=str(data_dir),
+        compact_threshold=config.agents.compact_threshold,
+        compact_keep_ratio=config.agents.compact_keep_ratio,
+        compact_chunk_size=config.agents.compact_chunk_size,
+        procedure_min_frequency=config.agents.procedure_min_frequency,
+        memory_max_sections=config.agents.memory_max_sections,
+        context_messages=config.agents.context_messages,
+        health_check_interval_s=config.agents.health_check_interval_s,
+        stuck_timeout_s=config.agents.stuck_timeout_s,
+        agent_factory=lambda persona, _memory, _context: FakeAgent(persona.id),
+    )
+
+    def bridge_factory(**kwargs):
+        return FakeChatBridge(**kwargs)
+
+    bridge_manager = BridgeManager(
+        registry=registry,
+        bridge_factory=lambda space_id, **kw: FakeChatBridge(space_id=space_id, **kw),
+        legacy_space_id=config.chat.space_id,
+    )
+
+    app = create_app(
+        registry=registry,
+        bridge_manager=bridge_manager,
+        chat_bridge_factory=lambda **kw: FakeChatBridge(**kw),
+        config=config,
+        config_path=str(config_path),
+        chat_auth_dir=str(tmp_path / "auth"),
+        global_memory_manager=GlobalMemoryManager(str(data_dir)),
+    )
+    return app
+
+
+def test_decisions_endpoint_empty(tmp_path: Path) -> None:
+    app = _build_test_app(tmp_path)
+
+    with TestClient(app) as client:
+        # Create an agent first
+        create = client.post(
+            "/agents",
+            json={"name": "DecBot", "emoji": "📝", "soul": "Decision logger"},
+        )
+        assert create.status_code == 200
+        agent_id = create.json()["id"]
+
+        # Query decisions (empty)
+        resp = client.get(f"/agents/{agent_id}/decisions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["decisions"] == []
+
+
+def test_decisions_endpoint_with_data(tmp_path: Path) -> None:
+    app = _build_test_app(tmp_path)
+
+    with TestClient(app) as client:
+        # Create an agent
+        create = client.post(
+            "/agents",
+            json={"name": "DecBot2", "emoji": "📝", "soul": "Decision logger"},
+        )
+        assert create.status_code == 200
+        agent_id = create.json()["id"]
+
+        # Manually write a decision to the agent's decision log
+        from g3lobster.agents.persona import agent_dir
+        from g3lobster.memory.decisions import DecisionLog
+
+        config = app.state.config
+        log = DecisionLog(str(Path(agent_dir(config.agents.data_dir, agent_id)) / ".memory"))
+        log.append(session_id="s1", decision="Use Redis for caching", tags=["infra"])
+        log.append(session_id="s2", decision="Use PostgreSQL for storage", tags=["db"])
+
+        # Query all decisions
+        resp = client.get(f"/agents/{agent_id}/decisions")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["decisions"]) == 2
+
+        # Query with keyword filter
+        resp = client.get(f"/agents/{agent_id}/decisions", params={"q": "Redis"})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["decisions"]) == 1
+        assert "Redis" in data["decisions"][0]["decision"]
+
+        # Query with limit
+        resp = client.get(f"/agents/{agent_id}/decisions", params={"limit": 1})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data["decisions"]) == 1


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #80.

Adds a searchable decision journal that preserves agent reasoning and captures decision rationale from conversations. Users can now ask "why did we decide X?" and get reliable answers via keyword search across decision entries.

## Changes
- **`g3lobster/cli/parser.py`**: Added `split_reasoning()` that returns `(reasoning, response)` tuple; `strip_reasoning()` now delegates to it
- **`g3lobster/pool/agent.py`**: Both `assign()` and `assign_stream()` now capture reasoning via `split_reasoning()` and store it as a `"reasoning"` event and in message metadata
- **`g3lobster/memory/decisions.py`** (new): `DecisionLog` class with append-only JSONL storage, keyword query, and listing — follows the `SessionStore` pattern
- **`g3lobster/memory/compactor.py`**: Added `_extract_decisions()` that scans compacted messages for decision-indicating patterns and logs them automatically
- **`g3lobster/memory/manager.py`**: Initializes `DecisionLog`, exposes `append_decision()`, `query_decisions()`, and `list_decisions()` methods
- **`g3lobster/memory/context.py`**: Added `_decisions_layer()` that injects top 3 relevant past decisions into agent prompts under "# Relevant Past Decisions"
- **`g3lobster/api/routes_agents.py`**: Added `GET /agents/{agent_id}/decisions` endpoint with optional `q` query parameter and `limit`
- **`g3lobster/api/models.py`**: Added `DecisionEntryResponse` and `DecisionQueryResponse` models
- **Tests**: 16 tests covering `split_reasoning()`, `DecisionLog` CRUD, decision extraction from compaction, MemoryManager integration, and the API endpoint

## Verification
- `pytest tests/`: 309 passed (pre-existing `test_timeout_policy` failure unrelated)

Closes #80