### PR TITLE
feat: Salience-classified journal with association graph

### DIFF
--- a/docs/memory-architecture.md
+++ b/docs/memory-architecture.md
@@ -20,8 +20,10 @@ data/
     │   ├── MEMORY.md                 # Agent short-term memory
     │   ├── PROCEDURES.md             # Agent-specific permanent procedures
     │   ├── CANDIDATES.json           # Candidate procedures (learning)
+    │   ├── associations.jsonl        # Association graph edges
     │   └── daily/
-    │       └── YYYY-MM-DD.md         # Long-term daily notes
+    │       ├── YYYY-MM-DD.md         # Long-term daily notes
+    │       └── YYYY-MM-DD.jsonl      # Structured journal entries
     └── sessions/
         └── {session_id}.jsonl        # Append-only session transcripts
 ```
@@ -69,6 +71,47 @@ Session reaches 40 messages
 ```
 
 **Key class:** `MemoryManager` in `memory/manager.py`
+
+### 2b. Journal Layer — Salience-Classified Entries
+
+The journal layer sits alongside daily notes, providing structured, salience-classified entries with an association graph. Each day gets a `.jsonl` file alongside the existing `.md` daily note.
+
+**SalienceLevel enum:** `critical`, `high`, `normal`, `low`, `noise`
+
+**JournalEntry fields:** `id`, `timestamp`, `content`, `salience`, `tags`, `source_session`, `associations`
+
+**JournalStore** (`daily/YYYY-MM-DD.jsonl`):
+- Append-only JSONL storage per day
+- Query by salience level, tags, date range
+- Backward compatible — existing `.md` files are unaffected
+
+**AssociationGraph** (`associations.jsonl`):
+- Edges stored as `{source_id, target_id, relation_type, weight}`
+- Automatic edges from shared tags and explicit associations
+- Traversable from any entry to find related entries
+
+**Journal entry format:**
+```json
+{"id": "uuid", "timestamp": "2026-03-11T...", "content": "...", "salience": "high", "tags": ["deploy"], "source_session": "sess-1", "associations": ["other-entry-id"]}
+```
+
+**Salience-weighted search:** When searching daily notes, JSONL journal files are also scanned. Results are weighted by salience level (critical=5x, high=3x, normal=1x, low=0.5x, noise=0.1x) for ranking.
+
+**Compaction integration:** When messages are compacted, they are classified by salience (user preferences → high, other content → normal) and written as structured `JournalEntry` objects in addition to the markdown highlights.
+
+**API endpoints:**
+- `GET /agents/{id}/journal` — Query entries with salience/tag/date filters
+- `POST /agents/{id}/journal` — Create a manual journal entry
+- `GET /agents/{id}/journal/{entry_id}/associations` — Traverse association graph
+
+**Configuration:**
+```yaml
+agents:
+  journal_salience_default: normal     # Default salience for new entries
+  journal_association_decay_days: 90   # Days before association edges age out
+```
+
+**Key classes:** `SalienceLevel`, `JournalEntry`, `JournalStore`, `AssociationGraph` in `memory/journal.py`
 
 ### 3. Procedure System — Learning from Patterns
 
@@ -173,6 +216,7 @@ MemoryManager.append_message(session_id, "user", text)
     │       ├── Summarize old messages (Gemini CLI)
     │       ├── Rewrite JSONL (compaction record + kept messages)
     │       ├── Append highlights to MEMORY.md
+    │       ├── Write structured JournalEntry objects (salience-classified)
     │       └── Extract + ingest procedure candidates
     │
     ▼

--- a/g3lobster/api/models.py
+++ b/g3lobster/api/models.py
@@ -196,3 +196,47 @@ class SpaceConfigRequest(BaseModel):
 
 class SleepAgentRequest(BaseModel):
     duration_s: float = Field(gt=0, le=86400, description="Sleep duration in seconds (max 24h)")
+
+
+# --- Journal models ---
+
+
+class JournalEntryResponse(BaseModel):
+    id: str
+    timestamp: str
+    content: str
+    salience: str
+    tags: List[str] = Field(default_factory=list)
+    source_session: str = ""
+    associations: List[str] = Field(default_factory=list)
+
+
+class JournalEntryCreateRequest(BaseModel):
+    content: str = Field(min_length=1)
+    salience: Optional[str] = None
+    tags: List[str] = Field(default_factory=list)
+    source_session: str = ""
+    associations: List[str] = Field(default_factory=list)
+
+
+class JournalQueryRequest(BaseModel):
+    salience_min: Optional[str] = None
+    tags: Optional[List[str]] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
+    limit: int = Field(default=50, ge=1, le=500)
+
+
+class JournalQueryResponse(BaseModel):
+    entries: List[JournalEntryResponse] = Field(default_factory=list)
+
+
+class AssociationResponse(BaseModel):
+    source_id: str
+    target_id: str
+    relation_type: str = "related"
+    weight: float = 1.0
+
+
+class AssociationListResponse(BaseModel):
+    associations: List[AssociationResponse] = Field(default_factory=list)

--- a/g3lobster/api/routes_agents.py
+++ b/g3lobster/api/routes_agents.py
@@ -22,6 +22,11 @@ from g3lobster.api.models import (
     AgentDetailResponse,
     AgentResponse,
     AgentUpdateRequest,
+    AssociationListResponse,
+    AssociationResponse,
+    JournalEntryCreateRequest,
+    JournalEntryResponse,
+    JournalQueryResponse,
     KnowledgeListResponse,
     LinkBotRequest,
     MemorySearchRequest,
@@ -42,6 +47,7 @@ from g3lobster.api.models import (
 from g3lobster.config import normalize_space_id
 from g3lobster.memory.global_memory import GlobalMemoryManager
 from g3lobster.memory.manager import MemoryManager
+from g3lobster.memory.journal import JournalEntry, SalienceLevel
 from g3lobster.memory.search import MemorySearchEngine
 from g3lobster.tasks.types import Task, TaskStatus
 
@@ -719,6 +725,98 @@ async def link_agent_bot(agent_id: str, payload: LinkBotRequest, request: Reques
         runtime.persona = saved
 
     return {"linked": True, "bot_user_id": saved.bot_user_id}
+
+
+@router.get("/{agent_id}/journal", response_model=JournalQueryResponse)
+async def query_journal(
+    agent_id: str,
+    request: Request,
+    salience_min: Optional[str] = Query(default=None),
+    tag: List[str] = Query(default=[]),
+    start_date: Optional[str] = Query(default=None),
+    end_date: Optional[str] = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+) -> JournalQueryResponse:
+    config = request.app.state.config
+    _ensure_persona(config.agents.data_dir, agent_id)
+
+    manager = _memory_manager(request, agent_id)
+    sal_min = SalienceLevel.from_value(salience_min) if salience_min else None
+    tags = tag if tag else None
+
+    from g3lobster.memory.search import MemorySearchEngine
+    parse_date = MemorySearchEngine._parse_date
+    start = parse_date(start_date)
+    end = parse_date(end_date)
+
+    entries = manager.query_journal(
+        salience_min=sal_min,
+        tags=tags,
+        start_date=start,
+        end_date=end,
+        limit=limit,
+    )
+    return JournalQueryResponse(
+        entries=[
+            JournalEntryResponse(
+                id=e.id,
+                timestamp=e.timestamp,
+                content=e.content,
+                salience=e.salience.value,
+                tags=e.tags,
+                source_session=e.source_session,
+                associations=e.associations,
+            )
+            for e in entries
+        ]
+    )
+
+
+@router.post("/{agent_id}/journal", response_model=JournalEntryResponse, status_code=201)
+async def create_journal_entry(
+    agent_id: str, payload: JournalEntryCreateRequest, request: Request
+) -> JournalEntryResponse:
+    config = request.app.state.config
+    _ensure_persona(config.agents.data_dir, agent_id)
+
+    manager = _memory_manager(request, agent_id)
+    entry = JournalEntry(
+        content=payload.content,
+        salience=SalienceLevel.from_value(payload.salience),
+        tags=payload.tags,
+        source_session=payload.source_session,
+        associations=payload.associations,
+    )
+    saved = manager.append_journal_entry(entry)
+    return JournalEntryResponse(
+        id=saved.id,
+        timestamp=saved.timestamp,
+        content=saved.content,
+        salience=saved.salience.value,
+        tags=saved.tags,
+        source_session=saved.source_session,
+        associations=saved.associations,
+    )
+
+
+@router.get("/{agent_id}/journal/{entry_id}/associations", response_model=AssociationListResponse)
+async def get_journal_associations(agent_id: str, entry_id: str, request: Request) -> AssociationListResponse:
+    config = request.app.state.config
+    _ensure_persona(config.agents.data_dir, agent_id)
+
+    manager = _memory_manager(request, agent_id)
+    edges = manager.association_graph.get_associations(entry_id)
+    return AssociationListResponse(
+        associations=[
+            AssociationResponse(
+                source_id=e.source_id,
+                target_id=e.target_id,
+                relation_type=e.relation_type,
+                weight=e.weight,
+            )
+            for e in edges
+        ]
+    )
 
 
 @router.post("/{agent_id}/test")

--- a/g3lobster/config.py
+++ b/g3lobster/config.py
@@ -27,6 +27,8 @@ class AgentsConfig:
     context_messages: int = 12
     health_check_interval_s: int = 30
     stuck_timeout_s: int = 0  # 0 disables stuck-agent auto-restart
+    journal_salience_default: str = "normal"
+    journal_association_decay_days: int = 90
 
 
 @dataclass

--- a/g3lobster/memory/journal.py
+++ b/g3lobster/memory/journal.py
@@ -1,0 +1,296 @@
+"""Salience-classified journal with association graph.
+
+Persists structured journal entries as JSONL files alongside existing daily
+markdown notes, and maintains an association graph linking related entries.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import asdict, dataclass, field
+from datetime import date, datetime, timezone
+from enum import Enum
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+class SalienceLevel(str, Enum):
+    """Importance classification for journal entries."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    NORMAL = "normal"
+    LOW = "low"
+    NOISE = "noise"
+
+    @classmethod
+    def from_value(cls, value: Optional[str]) -> "SalienceLevel":
+        if value is None:
+            return cls.NORMAL
+        normalized = str(value).strip().lower()
+        for item in cls:
+            if item.value == normalized:
+                return item
+        return cls.NORMAL
+
+    @property
+    def weight(self) -> float:
+        return _SALIENCE_WEIGHTS[self]
+
+
+_SALIENCE_WEIGHTS: Dict[SalienceLevel, float] = {
+    SalienceLevel.CRITICAL: 5.0,
+    SalienceLevel.HIGH: 3.0,
+    SalienceLevel.NORMAL: 1.0,
+    SalienceLevel.LOW: 0.5,
+    SalienceLevel.NOISE: 0.1,
+}
+
+
+@dataclass
+class JournalEntry:
+    """A single structured journal entry."""
+
+    id: str = field(default_factory=lambda: str(uuid.uuid4()))
+    timestamp: str = field(default_factory=lambda: datetime.now(tz=timezone.utc).isoformat())
+    content: str = ""
+    salience: SalienceLevel = SalienceLevel.NORMAL
+    tags: List[str] = field(default_factory=list)
+    source_session: str = ""
+    associations: List[str] = field(default_factory=list)
+
+    def as_dict(self) -> Dict[str, Any]:
+        data = asdict(self)
+        data["salience"] = self.salience.value
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "JournalEntry":
+        return cls(
+            id=str(data.get("id", str(uuid.uuid4()))),
+            timestamp=str(data.get("timestamp", "")),
+            content=str(data.get("content", "")),
+            salience=SalienceLevel.from_value(data.get("salience")),
+            tags=list(data.get("tags") or []),
+            source_session=str(data.get("source_session", "")),
+            associations=list(data.get("associations") or []),
+        )
+
+
+@dataclass
+class AssociationEdge:
+    """An edge in the association graph."""
+
+    source_id: str
+    target_id: str
+    relation_type: str = "related"
+    weight: float = 1.0
+
+    def as_dict(self) -> Dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "AssociationEdge":
+        return cls(
+            source_id=str(data.get("source_id", "")),
+            target_id=str(data.get("target_id", "")),
+            relation_type=str(data.get("relation_type", "related")),
+            weight=float(data.get("weight", 1.0)),
+        )
+
+
+class JournalStore:
+    """Persists journal entries as JSONL files under daily/.
+
+    Each day gets a ``YYYY-MM-DD.jsonl`` file alongside the existing ``.md``
+    daily note.  Entries are append-only within a file.
+    """
+
+    def __init__(self, daily_dir: str):
+        self.daily_dir = Path(daily_dir)
+        self.daily_dir.mkdir(parents=True, exist_ok=True)
+
+    def _jsonl_path(self, day: Optional[date] = None) -> Path:
+        target = day or date.today()
+        return self.daily_dir / f"{target.isoformat()}.jsonl"
+
+    def append(self, entry: JournalEntry) -> JournalEntry:
+        """Append a journal entry to the day's JSONL file."""
+        if not entry.timestamp:
+            entry.timestamp = datetime.now(tz=timezone.utc).isoformat()
+        entry_date = self._parse_entry_date(entry.timestamp)
+        path = self._jsonl_path(entry_date)
+        with path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(entry.as_dict(), ensure_ascii=False) + "\n")
+        return entry
+
+    def read_day(self, day: Optional[date] = None) -> List[JournalEntry]:
+        """Read all entries for a given day."""
+        path = self._jsonl_path(day)
+        return self._read_jsonl(path)
+
+    def get_entry(self, entry_id: str, day: Optional[date] = None) -> Optional[JournalEntry]:
+        """Find an entry by id.  If day is None, searches all days."""
+        if day:
+            for entry in self.read_day(day):
+                if entry.id == entry_id:
+                    return entry
+            return None
+        for path in sorted(self.daily_dir.glob("*.jsonl")):
+            for entry in self._read_jsonl(path):
+                if entry.id == entry_id:
+                    return entry
+        return None
+
+    def query(
+        self,
+        *,
+        salience_min: Optional[SalienceLevel] = None,
+        tags: Optional[List[str]] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        limit: int = 50,
+    ) -> List[JournalEntry]:
+        """Query entries with optional filters."""
+        salience_order = list(SalienceLevel)
+        min_index = salience_order.index(salience_min) if salience_min else len(salience_order) - 1
+
+        tag_set = {t.lower() for t in tags} if tags else None
+        results: List[JournalEntry] = []
+
+        for path in sorted(self.daily_dir.glob("*.jsonl"), reverse=True):
+            file_date = self._parse_stem_date(path.stem)
+            if file_date:
+                if start_date and file_date < start_date:
+                    continue
+                if end_date and file_date > end_date:
+                    continue
+
+            for entry in self._read_jsonl(path):
+                if salience_order.index(entry.salience) > min_index:
+                    continue
+                if tag_set and not tag_set.intersection(t.lower() for t in entry.tags):
+                    continue
+                results.append(entry)
+                if len(results) >= limit:
+                    return results
+
+        return results
+
+    def list_days(self) -> List[date]:
+        """Return sorted list of dates that have journal entries."""
+        days: List[date] = []
+        for path in sorted(self.daily_dir.glob("*.jsonl")):
+            d = self._parse_stem_date(path.stem)
+            if d:
+                days.append(d)
+        return days
+
+    @staticmethod
+    def _read_jsonl(path: Path) -> List[JournalEntry]:
+        if not path.exists():
+            return []
+        entries: List[JournalEntry] = []
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                entries.append(JournalEntry.from_dict(data))
+            except (json.JSONDecodeError, KeyError):
+                continue
+        return entries
+
+    @staticmethod
+    def _parse_entry_date(timestamp: str) -> date:
+        try:
+            return datetime.fromisoformat(timestamp.replace("Z", "+00:00")).date()
+        except (ValueError, AttributeError):
+            return date.today()
+
+    @staticmethod
+    def _parse_stem_date(stem: str) -> Optional[date]:
+        try:
+            return date.fromisoformat(stem)
+        except ValueError:
+            return None
+
+
+class AssociationGraph:
+    """Filesystem-backed association graph stored as a single JSONL file."""
+
+    def __init__(self, memory_dir: str):
+        self.memory_dir = Path(memory_dir)
+        self.memory_dir.mkdir(parents=True, exist_ok=True)
+        self._path = self.memory_dir / "associations.jsonl"
+
+    def add_edge(self, edge: AssociationEdge) -> None:
+        with self._path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(edge.as_dict(), ensure_ascii=False) + "\n")
+
+    def add_edges_from_entry(self, entry: JournalEntry) -> None:
+        """Create edges between the entry and all entries in its associations list."""
+        for target_id in entry.associations:
+            self.add_edge(AssociationEdge(
+                source_id=entry.id,
+                target_id=target_id,
+                relation_type="explicit",
+            ))
+
+    def add_tag_associations(self, entry: JournalEntry, other_entries: List[JournalEntry]) -> None:
+        """Create edges between entries sharing tags."""
+        entry_tags = {t.lower() for t in entry.tags}
+        if not entry_tags:
+            return
+        for other in other_entries:
+            if other.id == entry.id:
+                continue
+            other_tags = {t.lower() for t in other.tags}
+            shared = entry_tags & other_tags
+            if shared:
+                self.add_edge(AssociationEdge(
+                    source_id=entry.id,
+                    target_id=other.id,
+                    relation_type="shared_tags",
+                    weight=len(shared),
+                ))
+
+    def get_associations(self, entry_id: str) -> List[AssociationEdge]:
+        """Return all edges where entry_id is source or target."""
+        edges = self._read_all()
+        return [e for e in edges if e.source_id == entry_id or e.target_id == entry_id]
+
+    def get_neighbors(self, entry_id: str) -> List[str]:
+        """Return ids of all entries connected to the given entry."""
+        neighbors: List[str] = []
+        for edge in self.get_associations(entry_id):
+            if edge.source_id == entry_id:
+                neighbors.append(edge.target_id)
+            else:
+                neighbors.append(edge.source_id)
+        return neighbors
+
+    def _read_all(self) -> List[AssociationEdge]:
+        if not self._path.exists():
+            return []
+        edges: List[AssociationEdge] = []
+        try:
+            lines = self._path.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            lines = self._path.read_text(encoding="utf-8", errors="replace").splitlines()
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+                edges.append(AssociationEdge.from_dict(data))
+            except (json.JSONDecodeError, KeyError):
+                continue
+        return edges

--- a/g3lobster/memory/manager.py
+++ b/g3lobster/memory/manager.py
@@ -9,6 +9,12 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from g3lobster.memory.compactor import CompactionEngine
+from g3lobster.memory.journal import (
+    AssociationGraph,
+    JournalEntry,
+    JournalStore,
+    SalienceLevel,
+)
 from g3lobster.memory.procedures import (
     CandidateStore,
     Procedure,
@@ -67,6 +73,9 @@ class MemoryManager:
             min_frequency=self.procedure_min_frequency,
         )
         self.candidate_store = CandidateStore(str(self.candidates_file))
+        self.journal_store = JournalStore(str(self.daily_dir))
+        self.association_graph = AssociationGraph(str(self.memory_dir))
+
         self.compactor = CompactionEngine(
             session_store=self.sessions,
             procedure_store=self.procedure_store,
@@ -212,6 +221,35 @@ class MemoryManager:
         with path.open("a", encoding="utf-8") as handle:
             handle.write(text.strip() + "\n")
 
+    def append_journal_entry(self, entry: JournalEntry) -> JournalEntry:
+        """Write a structured journal entry and also append to the daily .md for backward compat."""
+        saved = self.journal_store.append(entry)
+        # Append human-readable line to existing markdown daily note.
+        self.append_daily_note(
+            f"[{entry.salience.value}] {entry.content[:200]}",
+            day=self.journal_store._parse_entry_date(entry.timestamp),
+        )
+        # Build association graph edges.
+        self.association_graph.add_edges_from_entry(entry)
+        return saved
+
+    def query_journal(
+        self,
+        *,
+        salience_min: Optional[SalienceLevel] = None,
+        tags: Optional[List[str]] = None,
+        start_date: Optional[date] = None,
+        end_date: Optional[date] = None,
+        limit: int = 50,
+    ) -> List[JournalEntry]:
+        return self.journal_store.query(
+            salience_min=salience_min,
+            tags=tags,
+            start_date=start_date,
+            end_date=end_date,
+            limit=limit,
+        )
+
     def append_message(
         self,
         session_id: str,
@@ -270,6 +308,16 @@ class MemoryManager:
             or cls._IMPORTANT_PATTERN.search(text)
         )
 
+    @staticmethod
+    def _classify_compaction_salience(role: str, content: str, is_preference: bool) -> SalienceLevel:
+        """Classify a compacted message by salience level."""
+        if is_preference:
+            return SalienceLevel.HIGH
+        if role == "user":
+            return SalienceLevel.NORMAL
+        # Tool outputs and assistant responses default to normal.
+        return SalienceLevel.NORMAL
+
     def _maybe_compact(self, session_id: str, message_count: Optional[int] = None) -> bool:
         def _flush_compacted_messages(messages: List[Dict[str, object]]) -> None:
             highlights: List[str] = []
@@ -281,7 +329,20 @@ class MemoryManager:
                 content = str(message.get("content", "")).strip()
                 if not role or not content:
                     continue
-                if role == "user" and self._is_user_preference(content):
+
+                is_pref = role == "user" and self._is_user_preference(content)
+                salience = self._classify_compaction_salience(role, content, is_pref)
+
+                # Write structured journal entry for each compacted highlight.
+                journal_entry = JournalEntry(
+                    content=content[:300],
+                    salience=salience,
+                    tags=["compaction"],
+                    source_session=session_id,
+                )
+                self.journal_store.append(journal_entry)
+
+                if is_pref:
                     highlights.append(f"- user preference: {content[:180]}")
                 elif len(highlights) < 6:
                     highlights.append(f"- {role}: {content[:180]}")

--- a/g3lobster/memory/search.py
+++ b/g3lobster/memory/search.py
@@ -3,13 +3,23 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import Iterable, List, Optional, Sequence, Set
+from typing import Dict, Iterable, List, Optional, Sequence, Set
+
+from g3lobster.memory.journal import JournalEntry, JournalStore, SalienceLevel
 
 
 SUPPORTED_MEMORY_TYPES = {"memory", "procedures", "daily", "session", "knowledge"}
+
+_SALIENCE_SEARCH_WEIGHTS: Dict[str, float] = {
+    SalienceLevel.CRITICAL.value: 5.0,
+    SalienceLevel.HIGH.value: 3.0,
+    SalienceLevel.NORMAL.value: 1.0,
+    SalienceLevel.LOW.value: 0.5,
+    SalienceLevel.NOISE.value: 0.1,
+}
 
 
 @dataclass
@@ -20,6 +30,7 @@ class MemorySearchHit:
     snippet: str
     line_number: int
     timestamp: Optional[str] = None
+    salience_weight: float = 1.0
 
     def as_dict(self) -> dict:
         return {
@@ -282,6 +293,17 @@ class MemorySearchEngine:
                             file_date=file_date,
                         )
                     )
+                # Also scan JSONL journal files for salience-weighted hits.
+                hits.extend(
+                    self._search_journal_jsonl(
+                        daily_dir=daily_dir,
+                        agent_id=agent_id,
+                        query=normalized_query,
+                        query_terms=query_terms,
+                        start=start,
+                        end=end,
+                    )
+                )
 
             if "session" in selected_types:
                 hits.extend(
@@ -315,5 +337,69 @@ class MemorySearchEngine:
                         )
                     )
 
-        hits.sort(key=self._sort_key, reverse=True)
+        hits.sort(key=self._weighted_sort_key, reverse=True)
         return hits[:capped_limit]
+
+    @staticmethod
+    def _weighted_sort_key(hit: MemorySearchHit) -> float:
+        """Sort by timestamp weighted by salience."""
+        base = MemorySearchEngine._sort_key(hit)
+        return base * hit.salience_weight
+
+    def _search_journal_jsonl(
+        self,
+        *,
+        daily_dir: Path,
+        agent_id: str,
+        query: str,
+        query_terms: Sequence[str],
+        start: Optional[date],
+        end: Optional[date],
+    ) -> List[MemorySearchHit]:
+        """Search JSONL journal files and apply salience-based weighting."""
+        hits: List[MemorySearchHit] = []
+        for path in sorted(daily_dir.glob("*.jsonl")):
+            file_date = self._parse_date(path.stem)
+            if not self._date_in_range(file_date, start, end):
+                continue
+
+            line_number = 0
+            try:
+                lines = path.read_text(encoding="utf-8").splitlines()
+            except UnicodeDecodeError:
+                lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+
+            for raw in lines:
+                line_number += 1
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    data = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                content = str(data.get("content", ""))
+                if not self._matches(content, query, query_terms):
+                    continue
+
+                salience = str(data.get("salience", "normal"))
+                weight = _SALIENCE_SEARCH_WEIGHTS.get(salience, 1.0)
+                timestamp = data.get("timestamp")
+
+                tags = data.get("tags", [])
+                tag_str = f" [{', '.join(tags)}]" if tags else ""
+                snippet = f"[{salience}]{tag_str} {content}".strip()
+
+                hits.append(
+                    MemorySearchHit(
+                        agent_id=agent_id,
+                        memory_type="daily",
+                        source=self._relative_source(path),
+                        snippet=snippet,
+                        line_number=line_number,
+                        timestamp=timestamp if isinstance(timestamp, str) else None,
+                        salience_weight=weight,
+                    )
+                )
+        return hits

--- a/tests/test_journal.py
+++ b/tests/test_journal.py
@@ -1,0 +1,253 @@
+"""Tests for salience-classified journal and association graph."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+
+from g3lobster.memory.journal import (
+    AssociationEdge,
+    AssociationGraph,
+    JournalEntry,
+    JournalStore,
+    SalienceLevel,
+)
+from g3lobster.memory.manager import MemoryManager
+from g3lobster.memory.search import MemorySearchEngine
+
+
+# --- SalienceLevel ---
+
+
+def test_salience_level_from_value():
+    assert SalienceLevel.from_value("critical") == SalienceLevel.CRITICAL
+    assert SalienceLevel.from_value("HIGH") == SalienceLevel.HIGH
+    assert SalienceLevel.from_value(None) == SalienceLevel.NORMAL
+    assert SalienceLevel.from_value("bogus") == SalienceLevel.NORMAL
+
+
+def test_salience_level_weights():
+    assert SalienceLevel.CRITICAL.weight == 5.0
+    assert SalienceLevel.HIGH.weight == 3.0
+    assert SalienceLevel.NORMAL.weight == 1.0
+    assert SalienceLevel.LOW.weight == 0.5
+    assert SalienceLevel.NOISE.weight == 0.1
+
+
+# --- JournalEntry ---
+
+
+def test_journal_entry_roundtrip():
+    entry = JournalEntry(
+        content="test content",
+        salience=SalienceLevel.HIGH,
+        tags=["deploy", "prod"],
+        source_session="sess-1",
+    )
+    data = entry.as_dict()
+    restored = JournalEntry.from_dict(data)
+    assert restored.content == "test content"
+    assert restored.salience == SalienceLevel.HIGH
+    assert restored.tags == ["deploy", "prod"]
+    assert restored.source_session == "sess-1"
+    assert restored.id == entry.id
+
+
+# --- JournalStore CRUD ---
+
+
+def test_journal_store_append_and_read(tmp_path):
+    store = JournalStore(str(tmp_path / "daily"))
+    entry = JournalEntry(content="first entry", salience=SalienceLevel.HIGH, tags=["test"])
+    store.append(entry)
+
+    entries = store.read_day(date.today())
+    assert len(entries) == 1
+    assert entries[0].content == "first entry"
+    assert entries[0].salience == SalienceLevel.HIGH
+
+
+def test_journal_store_get_entry(tmp_path):
+    store = JournalStore(str(tmp_path / "daily"))
+    entry = JournalEntry(content="findable", tags=["lookup"])
+    store.append(entry)
+
+    found = store.get_entry(entry.id)
+    assert found is not None
+    assert found.content == "findable"
+
+    assert store.get_entry("nonexistent") is None
+
+
+def test_journal_store_query_by_salience(tmp_path):
+    store = JournalStore(str(tmp_path / "daily"))
+    store.append(JournalEntry(content="critical item", salience=SalienceLevel.CRITICAL))
+    store.append(JournalEntry(content="high item", salience=SalienceLevel.HIGH))
+    store.append(JournalEntry(content="normal item", salience=SalienceLevel.NORMAL))
+    store.append(JournalEntry(content="noise item", salience=SalienceLevel.NOISE))
+
+    results = store.query(salience_min=SalienceLevel.HIGH)
+    assert len(results) == 2
+    contents = {e.content for e in results}
+    assert "critical item" in contents
+    assert "high item" in contents
+
+
+def test_journal_store_query_by_tags(tmp_path):
+    store = JournalStore(str(tmp_path / "daily"))
+    store.append(JournalEntry(content="deploy note", tags=["deploy"]))
+    store.append(JournalEntry(content="test note", tags=["testing"]))
+
+    results = store.query(tags=["deploy"])
+    assert len(results) == 1
+    assert results[0].content == "deploy note"
+
+
+def test_journal_store_query_limit(tmp_path):
+    store = JournalStore(str(tmp_path / "daily"))
+    for i in range(10):
+        store.append(JournalEntry(content=f"entry {i}"))
+
+    results = store.query(limit=3)
+    assert len(results) == 3
+
+
+def test_journal_store_list_days(tmp_path):
+    store = JournalStore(str(tmp_path / "daily"))
+    store.append(JournalEntry(content="today's entry"))
+
+    days = store.list_days()
+    assert date.today() in days
+
+
+# --- AssociationGraph ---
+
+
+def test_association_graph_add_and_get(tmp_path):
+    graph = AssociationGraph(str(tmp_path / "memory"))
+    edge = AssociationEdge(source_id="a", target_id="b", relation_type="related", weight=1.5)
+    graph.add_edge(edge)
+
+    edges = graph.get_associations("a")
+    assert len(edges) == 1
+    assert edges[0].target_id == "b"
+    assert edges[0].weight == 1.5
+
+    # Also found from target side.
+    edges_b = graph.get_associations("b")
+    assert len(edges_b) == 1
+    assert edges_b[0].source_id == "a"
+
+
+def test_association_graph_get_neighbors(tmp_path):
+    graph = AssociationGraph(str(tmp_path / "memory"))
+    graph.add_edge(AssociationEdge(source_id="a", target_id="b"))
+    graph.add_edge(AssociationEdge(source_id="a", target_id="c"))
+    graph.add_edge(AssociationEdge(source_id="d", target_id="a"))
+
+    neighbors = graph.get_neighbors("a")
+    assert set(neighbors) == {"b", "c", "d"}
+
+
+def test_association_graph_add_edges_from_entry(tmp_path):
+    graph = AssociationGraph(str(tmp_path / "memory"))
+    entry = JournalEntry(id="e1", content="test", associations=["e2", "e3"])
+    graph.add_edges_from_entry(entry)
+
+    edges = graph.get_associations("e1")
+    assert len(edges) == 2
+    targets = {e.target_id for e in edges}
+    assert targets == {"e2", "e3"}
+
+
+def test_association_graph_tag_associations(tmp_path):
+    graph = AssociationGraph(str(tmp_path / "memory"))
+    entry_a = JournalEntry(id="a", content="alpha", tags=["deploy", "prod"])
+    entry_b = JournalEntry(id="b", content="beta", tags=["deploy", "staging"])
+    entry_c = JournalEntry(id="c", content="gamma", tags=["testing"])
+
+    graph.add_tag_associations(entry_a, [entry_b, entry_c])
+    edges = graph.get_associations("a")
+    assert len(edges) == 1
+    assert edges[0].target_id == "b"
+    assert edges[0].relation_type == "shared_tags"
+
+
+# --- MemoryManager journal integration ---
+
+
+def test_memory_manager_append_journal_entry(tmp_path):
+    manager = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=999)
+    entry = JournalEntry(content="important note", salience=SalienceLevel.HIGH, tags=["test"])
+    saved = manager.append_journal_entry(entry)
+
+    assert saved.id == entry.id
+
+    # Check that the daily .md also has the entry.
+    md_path = manager.daily_note_path()
+    assert md_path.exists()
+    md_content = md_path.read_text(encoding="utf-8")
+    assert "[high] important note" in md_content
+
+    # Check journal query returns it.
+    results = manager.query_journal(salience_min=SalienceLevel.HIGH)
+    assert len(results) >= 1
+    assert any(e.content == "important note" for e in results)
+
+
+def test_memory_manager_backward_compat_daily_notes(tmp_path):
+    """Existing daily .md files should still work."""
+    manager = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=999)
+    manager.append_daily_note("plain text note")
+
+    md_path = manager.daily_note_path()
+    assert md_path.exists()
+    content = md_path.read_text(encoding="utf-8")
+    assert "plain text note" in content
+
+
+def test_compaction_creates_journal_entries(tmp_path):
+    """Compaction should write structured journal entries."""
+    manager = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=4)
+
+    manager.append_message("sess-1", "user", "I always prefer short answers")
+    manager.append_message("sess-1", "assistant", "Noted, will keep it brief")
+    manager.append_message("sess-1", "user", "tell me about pandas")
+    manager.append_message("sess-1", "assistant", "Pandas is a data library")
+
+    # After compaction, journal entries should exist.
+    entries = manager.journal_store.read_day(date.today())
+    assert len(entries) > 0
+    # At least one should have the compaction tag.
+    compaction_entries = [e for e in entries if "compaction" in e.tags]
+    assert len(compaction_entries) > 0
+
+
+# --- Salience-weighted search ---
+
+
+def test_salience_weighted_search(tmp_path):
+    """Journal JSONL entries should appear in search results with salience weighting."""
+    data_dir = tmp_path / "data" / "agents" / "test-agent"
+    memory_dir = data_dir / ".memory"
+    daily_dir = memory_dir / "daily"
+    daily_dir.mkdir(parents=True, exist_ok=True)
+
+    store = JournalStore(str(daily_dir))
+    store.append(JournalEntry(
+        content="critical deployment failure observed",
+        salience=SalienceLevel.CRITICAL,
+        tags=["deploy"],
+    ))
+    store.append(JournalEntry(
+        content="noise deployment log line",
+        salience=SalienceLevel.NOISE,
+        tags=["deploy"],
+    ))
+
+    engine = MemorySearchEngine(data_dir=str(tmp_path / "data"))
+    hits = engine.search("deployment", agent_ids=["test-agent"], memory_types=["daily"])
+
+    assert len(hits) == 2
+    # Critical should rank higher due to salience weight.
+    assert hits[0].salience_weight > hits[1].salience_weight
+    assert "critical" in hits[0].snippet.lower()


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #63.

Upgrades the daily journal from flat markdown files to structured, salience-classified entries with an explicit association graph. This enables agents to prioritize important memories, discover related concepts across time, and build a richer knowledge representation layer on top of the existing memory architecture.

## Changes
- **`g3lobster/memory/journal.py` (new)** — `SalienceLevel` enum (critical/high/normal/low/noise), `JournalEntry` dataclass, `JournalStore` (JSONL per day), `AssociationGraph` (JSONL edges file)
- **`g3lobster/memory/manager.py`** — Added `append_journal_entry()` and `query_journal()` methods; compaction now writes structured journal entries classified by salience
- **`g3lobster/memory/search.py`** — Scans `.jsonl` journal files alongside `.md` daily notes; applies salience-based weighting (critical=5x, high=3x, normal=1x, low=0.5x, noise=0.1x) for ranking
- **`g3lobster/api/routes_agents.py`** — `GET /agents/{id}/journal`, `POST /agents/{id}/journal`, `GET /agents/{id}/journal/{entry_id}/associations`
- **`g3lobster/api/models.py`** — `JournalEntryResponse`, `JournalEntryCreateRequest`, `JournalQueryResponse`, `AssociationResponse`, `AssociationListResponse`
- **`g3lobster/config.py`** — `journal_salience_default`, `journal_association_decay_days` config knobs
- **`docs/memory-architecture.md`** — Documented journal layer and association graph
- **`tests/test_journal.py`** — 17 tests covering CRUD, salience classification, graph traversal, backward compatibility, and salience-weighted search

## Verification
- `pytest tests/`: 165 passed, 2 skipped (pre-existing skips)

Closes #63