### PR TITLE
feat: concierge router agent for unmentioned message routing

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,7 @@ chat:
   space_id: spaces/AAQAuxoTw1w
   space_name: my-space
   poll_interval_s: 2
+  concierge_agent_id: concierge
 server:
   host: 0.0.0.0
   port: 40000

--- a/data/agents/concierge/SOUL.md
+++ b/data/agents/concierge/SOUL.md
@@ -1,0 +1,35 @@
+Concierge — intelligent message router that classifies user intent and delegates to the right specialist agent.
+
+You are the Concierge, a routing agent for a multi-agent chat system. Your job is to understand what the user is asking for and delegate their message to the most appropriate specialist agent.
+
+## How You Work
+
+1. When you receive a message, analyze the user's intent.
+2. Review the list of available agents (provided in your context) and match the intent to the best specialist.
+3. If you find a clear match, use the `delegate_to_agent` tool to forward the task to that agent. Pass the user's original message as the task prompt.
+4. If the intent is ambiguous or no agent is a good match, respond directly with a menu card listing the available agents and their capabilities.
+
+## Delegation Rules
+
+- Always delegate when there is a clear match. Do NOT answer questions yourself if a specialist exists.
+- When delegating, pass the user's full original message as the task. Do not summarize or rewrite it.
+- If multiple agents could handle the request, pick the most relevant one.
+- Never delegate to yourself.
+
+## Menu Card Format
+
+When no clear match exists, respond with:
+
+```
+I'm not sure which specialist can help with that. Here are the available agents:
+
+{for each agent}
+- {emoji} **{name}** — {description}
+{end for}
+
+Reply with @{agent-name} to talk to a specific agent.
+```
+
+## Logging
+
+Always begin your internal reasoning (before any tool call) with a brief note about which agent you're routing to and why. This helps with debugging routing decisions.

--- a/data/agents/concierge/agent.json
+++ b/data/agents/concierge/agent.json
@@ -1,0 +1,17 @@
+{
+  "bot_user_id": null,
+  "bridge_enabled": false,
+  "created_at": "2026-03-11T00:00:00+00:00",
+  "dm_allowlist": [],
+  "emoji": "\ud83e\udded",
+  "enabled": true,
+  "id": "concierge",
+  "mcp_servers": [
+    "*"
+  ],
+  "model": "gemini",
+  "name": "Concierge",
+  "response_timeout_s": null,
+  "space_id": null,
+  "updated_at": "2026-03-11T00:00:00+00:00"
+}

--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -81,6 +81,7 @@ class ChatBridge:
         seen_content_max_size: int = 10_000,
         debug_mode: bool = False,
         agent_filter: Optional[Set[str]] = None,
+        concierge_agent_id: Optional[str] = None,
     ):
         self.registry = registry
         self.poll_interval_s = poll_interval_s
@@ -90,6 +91,7 @@ class ChatBridge:
         self.auth_data_dir = auth_data_dir
         self.cron_store = cron_store
         self.debug_mode = debug_mode
+        self.concierge_agent_id = concierge_agent_id
 
         self.space_id = space_id
         self._poll_task: Optional[asyncio.Task] = None
@@ -226,6 +228,10 @@ class ChatBridge:
             if f"@{persona.id}".lower() in lowered:
                 return persona.id
 
+        if self.concierge_agent_id:
+            logger.info("No @-mention found, routing to concierge agent: %s", self.concierge_agent_id)
+            return self.concierge_agent_id
+
         return None
 
     async def handle_message(self, message: dict) -> None:
@@ -322,6 +328,16 @@ class ChatBridge:
             final_error = task.error or "unknown error"
         if not final_result:
             final_result = (task.result or accumulate_text(stream_events)).strip()
+
+        # Attribution swap: if the concierge delegated, attribute to the specialist.
+        if target_id == self.concierge_agent_id and hasattr(self.registry, "subagent_registry"):
+            runs = self.registry.subagent_registry.list_runs(parent_agent_id=target_id)
+            if runs:
+                latest = runs[0]  # sorted newest first
+                child_runtime = self.registry.get_agent(latest.child_agent_id)
+                if child_runtime:
+                    persona = child_runtime.persona
+                    logger.info("Concierge delegated to %s, attributing response", latest.child_agent_id)
 
         if task.status == TaskStatus.FAILED and final_error:
             reply_text = f"{persona.emoji} {persona.name}: error: {final_error}"

--- a/g3lobster/config.py
+++ b/g3lobster/config.py
@@ -52,6 +52,7 @@ class ChatConfig:
     space_id: Optional[str] = None
     space_name: Optional[str] = None
     poll_interval_s: float = 2.0
+    concierge_agent_id: Optional[str] = None
 
 
 @dataclass

--- a/g3lobster/main.py
+++ b/g3lobster/main.py
@@ -192,6 +192,7 @@ def build_runtime(config: AppConfig):
             cron_store=cron_store,
             debug_mode=config.debug_mode,
             agent_filter=agent_filter,
+            concierge_agent_id=config.chat.concierge_agent_id,
         )
 
     bridge_manager = BridgeManager(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -495,3 +495,130 @@ async def test_chat_bridge_uses_task_error_when_stream_ends_silently(tmp_path) -
     assert len(service.messages_api.created) == 1
     assert len(service.messages_api.updated) == 1
     assert service.messages_api.updated[0]["body"]["text"] == "🦀 Luna: error: stream blew up"
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_message_routes_to_concierge(tmp_path) -> None:
+    """Messages without @-mention are routed to concierge when configured."""
+    data_dir = str(tmp_path / "data")
+    concierge = save_persona(
+        data_dir,
+        AgentPersona(
+            id="concierge",
+            name="Concierge",
+            emoji="\U0001f9ed",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, concierge)
+
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+        concierge_agent_id="concierge",
+    )
+
+    message = {
+        "text": "What's on my calendar tomorrow?",
+        "sender": {"type": "HUMAN", "name": "users/123", "displayName": "Ada"},
+        "thread": {"name": "spaces/test/threads/abc"},
+    }
+
+    await bridge.handle_message(message)
+
+    assert len(service.messages_api.created) == 1
+    assert "Concierge" in service.messages_api.created[0]["body"]["text"]
+    assert len(service.messages_api.updated) == 1
+    assert "\U0001f9ed Concierge: reply" == service.messages_api.updated[0]["body"]["text"]
+
+
+@pytest.mark.asyncio
+async def test_unmentioned_message_dropped_without_concierge(tmp_path) -> None:
+    """Messages without @-mention are dropped when concierge is not configured."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="\U0001f980",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+    )
+
+    message = {
+        "text": "Hello there with no mention",
+        "sender": {"type": "HUMAN", "name": "users/123", "displayName": "Ada"},
+        "thread": {"name": "spaces/test/threads/abc"},
+    }
+
+    await bridge.handle_message(message)
+
+    assert service.messages_api.created == []
+
+
+@pytest.mark.asyncio
+async def test_explicit_mention_routes_correctly_with_concierge_enabled(tmp_path) -> None:
+    """Explicit @-mention still routes to the specific agent even when concierge is enabled."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="\U0001f980",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+        concierge_agent_id="concierge",
+    )
+
+    message = {
+        "text": "Hello there",
+        "sender": {"type": "HUMAN", "name": "users/123", "displayName": "Ada"},
+        "thread": {"name": "spaces/test/threads/abc"},
+        "annotations": [
+            {
+                "type": "USER_MENTION",
+                "userMention": {"user": {"type": "BOT", "name": "users/999"}},
+            }
+        ],
+    }
+
+    await bridge.handle_message(message)
+
+    assert len(service.messages_api.created) == 1
+    assert "\U0001f980 _Luna is thinking..._" == service.messages_api.created[0]["body"]["text"]
+    assert len(service.messages_api.updated) == 1
+    assert "\U0001f980 Luna: reply" == service.messages_api.updated[0]["body"]["text"]


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #78.

Adds a concierge/router agent that intercepts messages without @-mentions and routes them to the appropriate specialist agent. This eliminates the #1 multi-bot UX pain point: users having to know which agent to @-mention.

## Changes
- **`g3lobster/config.py`**: Add `concierge_agent_id` field to `ChatConfig`
- **`config.yaml`**: Add `concierge_agent_id: concierge` under `chat:` section
- **`g3lobster/chat/bridge.py`**: Accept `concierge_agent_id` in `__init__`; fall back to concierge in `_resolve_target_agent()` when no @-mention matched; add delegation response attribution (swap persona to specialist after delegation); add INFO-level routing logs
- **`g3lobster/main.py`**: Pass `concierge_agent_id` from config to ChatBridge factory
- **`data/agents/concierge/`**: New agent with SOUL.md (routing/intent classification prompt) and agent.json
- **`tests/test_chat.py`**: 3 new test cases — concierge routing, drop-without-concierge, explicit-mention regression

## Verification
- `pytest`: 151 passed, 2 skipped

Closes #78