### PR TITLE
feat(gammawave): implement #82 — async standup conductor with memory-powered trends

### DIFF
--- a/g3lobster/cron/manager.py
+++ b/g3lobster/cron/manager.py
@@ -36,10 +36,12 @@ class CronManager:
         gemini_args: Optional[list] = None,
         gemini_timeout_s: float = 45.0,
         gemini_cwd: Optional[str] = None,
+        standup_orchestrator: Optional[object] = None,
     ) -> None:
         self._store = cron_store
         self._registry = registry
         self._scheduler = None  # initialised lazily to avoid import-time dependency
+        self._standup_orchestrator = standup_orchestrator
         self._consolidation_enabled = consolidation_enabled
         self._consolidation_schedule = consolidation_schedule
         self._consolidation_days_window = consolidation_days_window
@@ -142,6 +144,26 @@ class CronManager:
         logger.info("Firing cron task %s for agent %s", task_id, agent_id)
         now = datetime.now(tz=timezone.utc).isoformat()
         self._store.update_task(agent_id, task_id, last_run=now)
+
+        # Intercept standup cron instructions before they reach the agent.
+        if instruction.startswith("__standup_"):
+            from g3lobster.standup.cron_hooks import handle_standup_cron
+            start_time = time_mod.monotonic()
+            try:
+                handled = await handle_standup_cron(instruction, agent_id, self._standup_orchestrator)
+                duration = round(time_mod.monotonic() - start_time, 1)
+                status = "completed" if handled else "failed"
+                preview = f"Standup {instruction} {'handled' if handled else 'not handled'}"
+            except Exception:
+                duration = round(time_mod.monotonic() - start_time, 1)
+                status = "failed"
+                preview = "Exception during standup cron execution"
+                logger.exception("Standup cron task %s raised an exception", task_id)
+            self._store.record_run(agent_id, CronRunRecord(
+                task_id=task_id, fired_at=now, status=status,
+                duration_s=duration, result_preview=preview,
+            ))
+            return
 
         runtime = self._registry.get_agent(agent_id)
         if not runtime:

--- a/g3lobster/main.py
+++ b/g3lobster/main.py
@@ -196,6 +196,11 @@ def build_runtime(config: AppConfig):
         registry=registry,
     )
 
+    # Wire standup orchestrator into cron manager so __standup_*  instructions
+    # are intercepted instead of being sent to the agent as raw prompts.
+    if cron_manager is not None:
+        cron_manager._standup_orchestrator = standup_orchestrator
+
     def chat_bridge_factory(
         space_id: str,
         service=None,


### PR DESCRIPTION
## Summary

Wires the final missing piece of the standup conductor feature: CronManager interception of `__standup_prompt__` and `__standup_summary__` cron instructions, routing them to `StandupOrchestrator` instead of sending them as raw text prompts to agents.

The standup package (store, orchestrator, trends, cron_hooks, API routes, bridge integration, and 31 unit tests) was already implemented on main. This PR adds the CronManager glue that makes cron-triggered standups actually work end-to-end.

## Changes

- Add `standup_orchestrator` parameter to `CronManager.__init__()`
- Intercept `__standup_*` instructions in `CronManager._fire()` and delegate to `handle_standup_cron()`
- Wire `standup_orchestrator` into `cron_manager` in `main.py` after both are created

## Verification

- `pytest tests/` — 300 passed, 2 failed (pre-existing on main: `test_timeout_policy.py`), 2 skipped
- All 31 standup tests pass

Closes #82

🤖 Generated with [Claude Code](https://claude.com/claude-code)