### PR TITLE
feat: breathing dot + organic badge CSS polish

### DIFF
--- a/g3lobster/static/css/zen.css
+++ b/g3lobster/static/css/zen.css
@@ -140,6 +140,67 @@ h3 {
   color: var(--danger);
 }
 
+@keyframes breathe {
+  0%, 100% { opacity: 1; transform: scale(1); }
+  50% { opacity: 0.6; transform: scale(0.85); }
+}
+
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
+
+.status-pill.busy .status-dot,
+.status-pill.running .status-dot,
+.status-pill.starting .status-dot {
+  animation: breathe 2s ease-in-out infinite;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: 2px 8px;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  border-radius: 2px 8px 2px 8px;
+}
+
+.collapsible-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  cursor: pointer;
+  user-select: none;
+  font-weight: 600;
+  font-size: 0.86rem;
+}
+
+.collapsible-chevron {
+  transition: transform 0.25s ease;
+  font-size: 0.7em;
+}
+
+.collapsible-header[aria-expanded="true"] .collapsible-chevron {
+  transform: rotate(90deg);
+}
+
+.collapsible-body {
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.3s ease;
+}
+
+.collapsible-body.open {
+  max-height: 2000px;
+}
+
 .actions {
   display: flex;
   flex-wrap: wrap;

--- a/g3lobster/static/js/agents.js
+++ b/g3lobster/static/js/agents.js
@@ -96,7 +96,7 @@ function bridgeTableMarkup(agents, bridgeByAgent) {
         <tr>
           <td>${escapeHtml(agent.emoji)} ${escapeHtml(agent.name)}</td>
           <td><code>${escapeHtml(bridge.space_id || "(not set)")}</code></td>
-          <td><span class="status-pill ${escapeHtml(status.className)}">${escapeHtml(status.label)}</span></td>
+          <td><span class="status-pill ${escapeHtml(status.className)}"><span class="status-dot"></span>${escapeHtml(status.label)}</span></td>
           <td class="bridge-controls">
             <button class="btn btn-secondary" data-action="bridge-start" data-agent-id="${escapeHtml(agent.id)}" ${status.canStart ? "" : "disabled"}>Start</button>
             <button class="btn btn-secondary" data-action="bridge-stop" data-agent-id="${escapeHtml(agent.id)}" ${status.canStop ? "" : "disabled"}>Stop</button>
@@ -293,7 +293,7 @@ export async function render(root, { onSetupChange }) {
         return `
           <button class="agent-chip ${active}" data-action="select-agent" data-agent-id="${escapeHtml(agent.id)}">
             <span class="chip-name">${escapeHtml(agent.emoji)} ${escapeHtml(agent.name)}</span>
-            <span class="status-pill ${escapeHtml(displayStatus.className)}">${escapeHtml(displayStatus.state)}</span>
+            <span class="status-pill ${escapeHtml(displayStatus.className)}"><span class="status-dot"></span>${escapeHtml(displayStatus.state)}</span>
           </button>
         `;
       })
@@ -315,7 +315,7 @@ export async function render(root, { onSetupChange }) {
           <div class="agent-meta">id: ${escapeHtml(agent.id)} · model: ${escapeHtml(agent.model)} · uptime: <span data-uptime-for="${escapeHtml(agent.id)}" data-uptime-s="${escapeHtml(uptime)}" data-running="${uptimeRunning}">${escapeHtml(uptime)}s</span></div>
         </div>
         <div class="actions">
-          <span class="status-pill ${escapeHtml(displayStatus.className)}">${escapeHtml(displayStatus.state)}</span>
+          <span class="status-pill ${escapeHtml(displayStatus.className)}"><span class="status-dot"></span>${escapeHtml(displayStatus.state)}</span>
           <button class="btn btn-secondary" data-action="start" data-agent-id="${escapeHtml(agent.id)}" ${actionDisabled}>${pending === "start" ? "Starting..." : "Start"}</button>
           <button class="btn btn-secondary" data-action="stop" data-agent-id="${escapeHtml(agent.id)}" ${actionDisabled}>${pending === "stop" ? "Stopping..." : "Stop"}</button>
           <button class="btn btn-secondary" data-action="restart" data-agent-id="${escapeHtml(agent.id)}" ${actionDisabled}>${pending === "restart" ? "Restarting..." : "Restart"}</button>
@@ -673,6 +673,16 @@ export async function render(root, { onSetupChange }) {
 
     startUptimeTicker();
 
+    for (const header of root.querySelectorAll(".collapsible-header")) {
+      header.addEventListener("click", () => {
+        const expanded = header.getAttribute("aria-expanded") === "true";
+        header.setAttribute("aria-expanded", String(!expanded));
+        const body = header.nextElementSibling;
+        if (body && body.classList.contains("collapsible-body")) {
+          body.classList.toggle("open", !expanded);
+        }
+      });
+    }
 
     root.querySelector("#create-agent-form")?.addEventListener("submit", async (event) => {
       event.preventDefault();


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #101.

Adds three micro-CSS polish patterns to make the web console feel alive and professional: (1) breathing dot animation that pulses on active/running/starting agent status pills, (2) organic asymmetric border-radius on `.badge` elements, and (3) a collapsible panel component with smooth expand/collapse and chevron rotation.

## Changes
- **zen.css**: Added `@keyframes breathe` animation, `.status-dot` styles with breathing animation for active states, `.badge` class with asymmetric `border-radius: 2px 8px 2px 8px`, and `.collapsible-header`/`.collapsible-body` component styles
- **agents.js**: Inserted `<span class="status-dot"></span>` inside status pills in `bridgeTableMarkup()`, `selectorMarkup()`, and `activeHeroMarkup()`
- **agents.js**: Added event delegation for `.collapsible-header` click-to-toggle with `aria-expanded` and `.open` class toggling

## Verification
- `make lint`: passing
- `make test`: pre-existing failure (missing python-multipart dependency) — unrelated to CSS/JS changes

Closes #101