### PR TITLE
feat: streaming text updates (draft stream loop)

### DIFF
--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import time
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, Optional, Set
@@ -87,9 +88,11 @@ class ChatBridge:
         agent_filter: Optional[Set[str]] = None,
         concierge_agent_id: Optional[str] = None,
         debounce_window_ms: int = 2000,
+        stream_update_interval_s: float = 1.0,
     ):
         self.registry = registry
         self.poll_interval_s = poll_interval_s
+        self.stream_update_interval_s = stream_update_interval_s
         self.service = service
         self.space_name = space_name
         self.spaces_config = Path(spaces_config or (Path.home() / ".gemini" / "chat_bridge_spaces.json"))
@@ -390,6 +393,8 @@ class ChatBridge:
         thinking_name: Optional[str] = thinking_msg.get("name") if thinking_msg else None
         last_progress_text = f"{persona.emoji} _{persona.name} is thinking..._"
         stream_events = []
+        accumulated_text = ""
+        last_update_time = time.monotonic()
 
         final_result: Optional[str] = None
         final_error: Optional[str] = None
@@ -402,6 +407,16 @@ class ChatBridge:
                 if thinking_name and progress_text != last_progress_text:
                     await self.update_message(thinking_name, progress_text)
                     last_progress_text = progress_text
+                    last_update_time = time.monotonic()
+            elif event.event_type == StreamEventType.MESSAGE:
+                if event.text:
+                    accumulated_text += event.text
+                    now = time.monotonic()
+                    if thinking_name and now - last_update_time >= self.stream_update_interval_s:
+                        progress_text = f"{persona.emoji} {persona.name}: {accumulated_text}"
+                        await self.update_message(thinking_name, progress_text)
+                        last_progress_text = progress_text
+                        last_update_time = now
             elif event.event_type == StreamEventType.RESULT:
                 if event.data.get("status") == "error":
                     error_data = event.data.get("error") or {}
@@ -416,7 +431,7 @@ class ChatBridge:
         if not final_error and task.status == TaskStatus.FAILED:
             final_error = task.error or "unknown error"
         if not final_result:
-            final_result = (task.result or accumulate_text(stream_events)).strip()
+            final_result = (task.result or accumulated_text or accumulate_text(stream_events)).strip()
 
         # Attribution: if concierge delegated, use the specialist's persona
         reply_persona = persona

--- a/g3lobster/config.py
+++ b/g3lobster/config.py
@@ -61,6 +61,7 @@ class ChatConfig:
     concierge_enabled: bool = False
     concierge_agent_id: str = "concierge"
     debounce_window_ms: int = 2000
+    stream_update_interval_s: float = 1.0
 
 
 @dataclass
@@ -299,6 +300,7 @@ def save_chat_config(chat: ChatConfig, config_path: str) -> None:
         "poll_interval_s": chat.poll_interval_s,
         "concierge_enabled": chat.concierge_enabled,
         "concierge_agent_id": chat.concierge_agent_id,
+        "stream_update_interval_s": chat.stream_update_interval_s,
     }
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -530,6 +530,28 @@ class FakeMultiRegistry:
         return agent_id in self._runtimes
 
 
+class FakeStreamingRuntime:
+    """Yields multiple MESSAGE events to test streaming throttle logic."""
+
+    def __init__(self, persona):
+        self.persona = persona
+
+    async def assign_stream(self, task):
+        from g3lobster.cli.streaming import StreamEvent, StreamEventType
+
+        task.status = TaskStatus.COMPLETED
+        # Emit several MESSAGE events — all arrive instantly (no real delay)
+        for chunk in ["Hello ", "world, ", "this ", "is ", "streaming!"]:
+            yield StreamEvent(
+                event_type=StreamEventType.MESSAGE,
+                data={"role": "assistant", "content": chunk, "delta": True},
+            )
+        yield StreamEvent(
+            event_type=StreamEventType.RESULT,
+            data={"status": "success"},
+        )
+
+
 @pytest.mark.asyncio
 async def test_unmentioned_message_routes_to_concierge(tmp_path) -> None:
     """When concierge is configured and no @-mention, route to concierge agent."""
@@ -732,3 +754,114 @@ def test_save_chat_config_persists_concierge_fields(tmp_path) -> None:
     assert chat["concierge_agent_id"] == "my-concierge"
     assert chat["enabled"] is True
     assert chat["space_id"] == "spaces/abc"
+
+
+@pytest.mark.asyncio
+async def test_streaming_text_updates_with_throttle(tmp_path) -> None:
+    """MESSAGE events cause intermediate updates, throttled by interval."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="🦀",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+    registry.runtime = FakeStreamingRuntime(persona)
+
+    # Use a very small interval so the first MESSAGE triggers an update
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+        stream_update_interval_s=0.0,
+        debounce_window_ms=0,
+    )
+
+    message = {
+        "text": "Stream me",
+        "sender": {"type": "HUMAN", "name": "users/123", "displayName": "Ada"},
+        "thread": {"name": "spaces/test/threads/abc"},
+        "annotations": [
+            {
+                "type": "USER_MENTION",
+                "userMention": {"user": {"type": "BOT", "name": "users/999"}},
+            }
+        ],
+    }
+
+    await bridge.handle_message(message)
+
+    # Expect: 1 create (thinking) + N intermediate updates + 1 final update
+    assert len(service.messages_api.created) == 1
+    assert service.messages_api.created[0]["body"]["text"] == "🦀 _Luna is thinking..._"
+
+    # At least one intermediate streaming update before the final one
+    assert len(service.messages_api.updated) >= 2
+
+    # The final update should contain the full accumulated text
+    final_text = service.messages_api.updated[-1]["body"]["text"]
+    assert final_text == "🦀 Luna: Hello world, this is streaming!"
+
+    # Intermediate updates should show partial accumulated text
+    first_update_text = service.messages_api.updated[0]["body"]["text"]
+    assert first_update_text.startswith("🦀 Luna: Hello")
+
+
+@pytest.mark.asyncio
+async def test_streaming_throttle_limits_updates(tmp_path) -> None:
+    """With a large interval, rapid MESSAGE events produce fewer intermediate updates."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="🦀",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+    registry.runtime = FakeStreamingRuntime(persona)
+
+    # Use a very large interval so no intermediate updates fire
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+        stream_update_interval_s=9999.0,
+        debounce_window_ms=0,
+    )
+
+    message = {
+        "text": "Stream throttled",
+        "sender": {"type": "HUMAN", "name": "users/123", "displayName": "Ada"},
+        "thread": {"name": "spaces/test/threads/abc"},
+        "annotations": [
+            {
+                "type": "USER_MENTION",
+                "userMention": {"user": {"type": "BOT", "name": "users/999"}},
+            }
+        ],
+    }
+
+    await bridge.handle_message(message)
+
+    # Only the final update — no intermediate streaming updates
+    assert len(service.messages_api.updated) == 1
+    assert service.messages_api.updated[0]["body"]["text"] == "🦀 Luna: Hello world, this is streaming!"


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #98.

Adds progressive streaming text updates to the Google Chat bridge. Instead of showing only "thinking..." until the full response is ready, MESSAGE events from the agent stream now cause intermediate update_message() calls that reveal response text as it's generated. Updates are throttled to a configurable interval (default 1s) to respect Google Chat API rate limits.

## Changes
- **`g3lobster/config.py`**: Added `stream_update_interval_s: float = 1.0` to `ChatConfig` for configurable throttle interval
- **`g3lobster/chat/bridge.py`**: Added throttled streaming text updates in the event loop — MESSAGE events accumulate text and trigger `update_message()` when the throttle interval has elapsed. TOOL_USE progress updates remain unchanged. Uses `accumulated_text` as primary fallback text source.
- **`tests/test_chat.py`**: Added two tests — one verifying intermediate streaming updates occur with a short interval, another verifying throttling suppresses rapid updates with a large interval

## Verification
- `pytest`: 150 passed, 2 skipped

Closes #98