### PR TITLE
feat: Lobster Tank dashboard — card-per-agent grid

### DIFF
--- a/g3lobster/api/routes_metrics.py
+++ b/g3lobster/api/routes_metrics.py
@@ -206,6 +206,7 @@ async def metrics_summary(request: Request) -> dict:
             "sessions_total": agent_data["sessions"]["total"],
             "messages_total": agent_data["messages"]["total"],
             "avg_response_s": agent_data["response_time"]["avg_s"],
+            "procedures_count": agent_data["memory"]["procedures_count"],
         })
 
     result = {"agents": summary}

--- a/g3lobster/static/css/zen.css
+++ b/g3lobster/static/css/zen.css
@@ -428,11 +428,10 @@ pre.transcript {
   color: var(--md-sys-color-on-surface-variant);
 }
 
-.agent-selector {
-  display: flex;
-  gap: var(--space-2);
-  overflow-x: auto;
-  padding-bottom: var(--space-2);
+.tank-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: var(--space-3);
 }
 
 .agent-chip {
@@ -444,10 +443,44 @@ pre.transcript {
   display: inline-flex;
   align-items: center;
   gap: var(--space-2);
-  cursor: pointer;
+  flex-wrap: wrap;
+}
+
+.tank-card {
+  border: 1px solid var(--md-sys-color-outline);
+  background: var(--md-sys-color-surface-container-low);
+  border-radius: var(--md-sys-shape-corner-medium);
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  cursor: default;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.tank-card.active {
+  border-color: var(--md-sys-color-primary);
+  box-shadow: 0 0 0 2px var(--md-sys-color-primary-container);
+  background: rgba(26, 115, 232, 0.04);
+}
+
+.tank-card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.tank-card-name {
+  font-weight: 700;
+  font-size: 1rem;
+}
+
+.tank-card-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
   flex-shrink: 0;
-  height: 32px;
-  font-size: 0.875rem;
   transition: background 0.2s;
 }
 
@@ -460,6 +493,49 @@ pre.transcript {
 
 .chip-name {
   font-weight: 500;
+}
+
+.tank-card-dot.dot-active {
+  background: var(--md-sys-color-tertiary);
+  box-shadow: 0 0 4px rgba(6, 118, 71, 0.5);
+}
+
+.tank-card-dot.dot-idle {
+  background: var(--md-sys-color-on-surface-variant);
+  opacity: 0.4;
+}
+
+.tank-card-state {
+  font-size: 0.76rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.tank-card-metrics {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  font-size: 0.82rem;
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.tank-metric-val {
+  font-weight: 700;
+  color: var(--md-sys-color-on-surface);
+}
+
+.tank-card-actions {
+  display: flex;
+  gap: var(--space-2);
+  margin-top: auto;
+}
+
+.btn-sm {
+  padding: 5px 10px;
+  font-size: 0.82rem;
+  border-radius: 8px;
 }
 
 .active-agent-hero {

--- a/g3lobster/static/js/agents.js
+++ b/g3lobster/static/js/agents.js
@@ -10,6 +10,7 @@ import {
   getAgentSession,
   getGlobalProcedures,
   getGlobalUserMemory,
+  getMetricsSummary,
   getSetupStatus,
   importAgent,
   linkAgentBot,
@@ -148,9 +149,11 @@ export async function render(root, { onSetupChange }) {
 
   let availableMcpServers = null;
   let pollIntervalId = null;
+  let metricsIntervalId = null;
   let uptimeIntervalId = null;
   let rerenderInFlight = null;
   let rerenderQueued = false;
+  let metricsCache = new Map();
 
   let globalUserMemory = "";
   let globalProcedures = "";
@@ -287,16 +290,43 @@ export async function render(root, { onSetupChange }) {
     return agents.find((item) => item.id === activeAgentId) || agents[0];
   }
 
-  function selectorMarkup(agents) {
+  function tankGridMarkup(agents, metricsMap) {
     return agents
       .map((agent) => {
         const active = agent.id === activeAgentId ? "active" : "";
         const displayStatus = lifecycleStatus(agent.id, agent.state);
+        const m = metricsMap.get(agent.id) || {};
+        const sessions = m.sessions_total ?? "—";
+        const procedures = m.procedures_count ?? "—";
+        const avgResp = m.avg_response_s != null ? `${m.avg_response_s}s` : "—";
+
+        const isRunning = !["stopped", "dead", "failed", "canceled", "error"].includes(
+          String(displayStatus.state).toLowerCase()
+        );
+        const statusDotClass = isRunning ? "dot-active" : "dot-idle";
+
+        const pending = displayStatus.pending;
+        const actionDisabled = pending ? "disabled" : "";
+        const toggleLabel = isRunning ? "Stop" : "Start";
+        const toggleAction = isRunning ? "stop" : "start";
+
         return `
-          <button class="agent-chip ${active}" data-action="select-agent" data-agent-id="${escapeHtml(agent.id)}">
-            <span class="chip-name">${escapeHtml(agent.emoji)} ${escapeHtml(agent.name)}</span>
-            <span class="status-pill ${escapeHtml(displayStatus.className)}"><span class="status-dot"></span>${escapeHtml(displayStatus.state)}</span>
-          </button>
+          <div class="tank-card ${active}" data-agent-id="${escapeHtml(agent.id)}">
+            <div class="tank-card-header">
+              <span class="tank-card-name">${escapeHtml(agent.emoji)} ${escapeHtml(agent.name)}</span>
+              <span class="tank-card-dot ${statusDotClass}"></span>
+              <span class="tank-card-state">${escapeHtml(displayStatus.state)}</span>
+            </div>
+            <div class="tank-card-metrics">
+              <div class="tank-metric"><span class="tank-metric-val">${escapeHtml(String(sessions))}</span> sessions</div>
+              <div class="tank-metric"><span class="tank-metric-val">${escapeHtml(String(procedures))}</span> procedures</div>
+              <div class="tank-metric"><span class="tank-metric-val">${escapeHtml(String(avgResp))}</span> avg</div>
+            </div>
+            <div class="tank-card-actions">
+              <button class="btn btn-secondary btn-sm" data-action="select-agent" data-agent-id="${escapeHtml(agent.id)}">View</button>
+              <button class="btn btn-secondary btn-sm" data-action="${toggleAction}" data-agent-id="${escapeHtml(agent.id)}" ${actionDisabled}>${escapeHtml(toggleLabel)}</button>
+            </div>
+          </div>
         `;
       })
       .join("");
@@ -555,6 +585,17 @@ export async function render(root, { onSetupChange }) {
       return;
     }
 
+    try {
+      const summary = await getMetricsSummary();
+      const newMap = new Map();
+      for (const entry of summary.agents || []) {
+        newMap.set(entry.agent_id, entry);
+      }
+      metricsCache = newMap;
+    } catch (_err) {
+      // Keep existing cache on failure
+    }
+
     const activeAgent = getActiveAgent(agents);
     if (activeAgent) {
       try {
@@ -648,10 +689,10 @@ export async function render(root, { onSetupChange }) {
         </div>
 
         <div class="step-panel">
-          <h2>Agent Selector</h2>
+          <h2>Lobster Tank</h2>
           ${
             agents.length
-              ? `<div class="agent-selector">${selectorMarkup(agents)}</div>`
+              ? `<div class="tank-grid">${tankGridMarkup(agents, metricsCache)}</div>`
               : "<p class='empty'>No agents yet.</p>"
           }
         </div>
@@ -1013,11 +1054,22 @@ export async function render(root, { onSetupChange }) {
     queueRerender();
   }, STATUS_POLL_INTERVAL_MS);
 
+  const METRICS_POLL_INTERVAL_MS = 30000;
+  metricsIntervalId = window.setInterval(() => {
+    if (!disposed) {
+      queueRerender();
+    }
+  }, METRICS_POLL_INTERVAL_MS);
+
   return {
     destroy() {
       disposed = true;
       clearStatusPoll();
       clearUptimeTicker();
+      if (metricsIntervalId !== null) {
+        window.clearInterval(metricsIntervalId);
+        metricsIntervalId = null;
+      }
     },
   };
 }

--- a/g3lobster/static/js/api.js
+++ b/g3lobster/static/js/api.js
@@ -210,6 +210,10 @@ export function deleteCronTask(agentId, taskId) {
   });
 }
 
+export function getMetricsSummary() {
+  return request("/agents/metrics/summary", { method: "GET" });
+}
+
 export function listMcpServers() {
   return request("/agents/_mcp/servers", { method: "GET" });
 }


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #100.

Replaces the flat agent chip selector with a card-per-agent grid ("Lobster Tank"). Each card shows live status (color-coded dot), key metrics (session count, procedure count, avg response time), and action buttons (View/Start/Stop). Metrics are fetched from the existing `/agents/metrics/summary` endpoint on page load and auto-refreshed every 30 seconds.

## Changes
- **`g3lobster/api/routes_metrics.py`**: Added `procedures_count` to the `/agents/metrics/summary` response
- **`g3lobster/static/js/api.js`**: Added `getMetricsSummary()` export function
- **`g3lobster/static/js/agents.js`**: Replaced `selectorMarkup()` with `tankGridMarkup()` rendering a CSS Grid of cards with emoji, name, status dot, metrics, and View/Start/Stop buttons; added metrics fetch on render and 30-second polling interval
- **`g3lobster/static/css/zen.css`**: Replaced `.agent-selector`/`.agent-chip` styles with `.tank-grid`/`.tank-card` responsive card grid layout

## Verification
- `make test`: 148 passed, 2 skipped
- `make lint`: passing

Closes #100