### PR TITLE
feat: emoji status reactions for agent progress

### DIFF
--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -442,6 +442,12 @@ class ChatBridge:
                     last_progress_text = progress_text
                     last_update_time = time.monotonic()
             elif event.event_type == StreamEventType.MESSAGE:
+                # 🔥 — generating (first message event, if no tool use triggered it)
+                if not _first_tool_use and user_message_name:
+                    _first_tool_use = True
+                    reaction_name = await self.transition_reaction(
+                        user_message_name, reaction_name, "🔥"
+                    )
                 if event.text:
                     accumulated_text += event.text
                     now = time.monotonic()

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -940,21 +940,22 @@ def _make_message(text="Hello there", name="spaces/test/messages/user1"):
 
 @pytest.mark.asyncio
 async def test_reaction_progression_success(tmp_path) -> None:
-    """On a successful task, reactions progress: 👀 → 🤔 → ✅."""
+    """On a successful task, reactions progress: 👀 → 🤔 → 🔥 → ✅."""
     bridge, service = _make_bridge_and_service(tmp_path)
     reactions_api = service.messages_api._reactions_api
 
     await bridge.handle_message(_make_message())
 
     user_msg = "spaces/test/messages/user1"
-    # Created: 👀, 🤔, ✅
-    assert len(reactions_api.created) == 3
+    # Created: 👀, 🤔, 🔥 (on first MESSAGE event), ✅
+    assert len(reactions_api.created) == 4
     assert reactions_api.created[0]["body"] == {"emoji": {"unicode": "👀"}}
     assert reactions_api.created[0]["parent"] == user_msg
     assert reactions_api.created[1]["body"] == {"emoji": {"unicode": "🤔"}}
-    assert reactions_api.created[2]["body"] == {"emoji": {"unicode": "✅"}}
-    # Deleted: 👀 (when 🤔 added), 🤔 (when ✅ added)
-    assert len(reactions_api.deleted) == 2
+    assert reactions_api.created[2]["body"] == {"emoji": {"unicode": "🔥"}}
+    assert reactions_api.created[3]["body"] == {"emoji": {"unicode": "✅"}}
+    # Deleted: 👀, 🤔, 🔥
+    assert len(reactions_api.deleted) == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #97.

Adds emoji reaction progression on the user's original Google Chat message to provide instant visual feedback of agent processing state: 👀 (received) → 🤔 (thinking) → 🔥 (generating) → ✅ (done) / ❌ (error). Reactions are fire-and-forget — failures are logged at debug level and never block agent processing. The existing "thinking" message behavior is preserved unchanged.

## Changes
- Added `add_reaction()`, `remove_reaction()`, and `transition_reaction()` helper methods to `ChatBridge`
- Hooked reaction transitions into `handle_message()` at each processing stage:
  - 👀 on message receipt (after target agent resolved)
  - 🤔 when task is created and agent starts thinking
  - 🔥 on first TOOL_USE stream event
  - ✅ on successful completion, ❌ on error/failure
- All reaction calls guarded by `user_message_name` presence check
- Added 8 unit tests covering: full progression (success, tool-use, error), no-name skip, API failure resilience, and individual helper methods
- Updated `FakeMessagesAPI` test fixture with `FakeReactionsAPI` for reaction mocking

## Verification
- `pytest tests/test_chat.py`: 15/15 passing (8 new reaction tests)
- `pytest tests/`: 156 passed, 2 skipped

Closes #97