### PR TITLE
feat: wire export/import UI for agents

### DIFF
--- a/g3lobster/static/js/agents.js
+++ b/g3lobster/static/js/agents.js
@@ -3,6 +3,7 @@ import {
   createCronTask,
   deleteAgent,
   deleteCronTask,
+  exportAgentUrl,
   getAgent,
   getAgentMemory,
   getAgentProcedures,
@@ -10,6 +11,7 @@ import {
   getGlobalProcedures,
   getGlobalUserMemory,
   getSetupStatus,
+  importAgent,
   linkAgentBot,
   listAgentSessions,
   listAgents,
@@ -320,6 +322,7 @@ export async function render(root, { onSetupChange }) {
           <button class="btn btn-secondary" data-action="stop" data-agent-id="${escapeHtml(agent.id)}" ${actionDisabled}>${pending === "stop" ? "Stopping..." : "Stop"}</button>
           <button class="btn btn-secondary" data-action="restart" data-agent-id="${escapeHtml(agent.id)}" ${actionDisabled}>${pending === "restart" ? "Restarting..." : "Restart"}</button>
           <button class="btn btn-secondary" data-action="test" data-agent-id="${escapeHtml(agent.id)}" ${actionDisabled}>Send Test</button>
+          <a class="btn btn-secondary" href="${exportAgentUrl(agent.id)}" download="${escapeHtml(agent.id)}.g3agent">Export</a>
           <button class="btn btn-danger" data-action="delete" data-agent-id="${escapeHtml(agent.id)}" ${actionDisabled}>Delete</button>
         </div>
       </section>
@@ -621,6 +624,8 @@ export async function render(root, { onSetupChange }) {
             </div>
             <div class="actions" style="grid-column: 1 / -1;">
               <button class="btn btn-primary" type="submit">Create Agent</button>
+              <input type="file" id="import-agent-file" accept=".g3agent,.zip" style="display:none" />
+              <button class="btn btn-secondary" type="button" data-action="import-agent">Import Agent</button>
             </div>
           </form>
         </div>
@@ -857,6 +862,29 @@ export async function render(root, { onSetupChange }) {
               await linkAgentBot(agentId, botUserId);
               setNotice("success", `Linked bot id for ${agentId}.`);
             }
+          } else if (action === "import-agent") {
+            const fileInput = root.querySelector("#import-agent-file");
+            if (!fileInput) return;
+            fileInput.value = "";
+            fileInput.onchange = async () => {
+              const file = fileInput.files?.[0];
+              if (!file) return;
+              try {
+                const result = await importAgent(file, false);
+                activeAgentId = result.agent_id;
+                setNotice("success", `Imported agent "${result.agent_id}" successfully.`);
+              } catch (err) {
+                if (err.status === 409) {
+                  setNotice("error", `Agent already exists. Re-upload with overwrite or rename the agent. (${err.message})`);
+                } else {
+                  const message = err instanceof Error ? err.message : String(err);
+                  setNotice("error", `Import failed: ${message}`);
+                }
+              }
+              queueRerender();
+            };
+            fileInput.click();
+            return;
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/g3lobster/static/js/api.js
+++ b/g3lobster/static/js/api.js
@@ -217,3 +217,32 @@ export function listMcpServers() {
 export function toggleDebugMode() {
   return request("/setup/debug-mode", { method: "POST" });
 }
+
+export function exportAgentUrl(agentId) {
+  return `/agents/${encodeURIComponent(agentId)}/export`;
+}
+
+export async function importAgent(file, overwrite = false) {
+  const form = new FormData();
+  form.append("archive", file);
+  const qs = overwrite ? "?overwrite=true" : "";
+  const response = await fetch(`/agents/import${qs}`, {
+    method: "POST",
+    body: form,
+  });
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`;
+    try {
+      const payload = await response.json();
+      if (payload?.detail) {
+        detail = typeof payload.detail === "string" ? payload.detail : JSON.stringify(payload.detail);
+      }
+    } catch (_err) {
+      // fallback detail
+    }
+    const err = new Error(detail);
+    err.status = response.status;
+    throw err;
+  }
+  return response.json();
+}


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #94.

Wires the existing export/import API endpoints (`GET /agents/{id}/export` and `POST /agents/import`) into the web console UI. The backend was already complete — this adds the missing client-side integration so users can export and import agents directly from the browser.

## Changes
- **`api.js`**: Added `exportAgentUrl(agentId)` helper (returns download URL) and `importAgent(file, overwrite)` function (POST with FormData, bypasses default JSON Content-Type)
- **`agents.js`**: Added `exportAgentUrl` and `importAgent` to imports
- **`agents.js` hero card**: Added Export `<a>` button with `download` attribute for native browser download of `.g3agent` ZIP files
- **`agents.js` Add Agent panel**: Added hidden file input (`.g3agent`/`.zip`) and "Import Agent" button that triggers file selection
- **`agents.js` action handlers**: Added `import-agent` handler with success toast, 409 conflict error messaging, and general error handling

## Verification
- `make test`: 148 passed, 2 skipped
- `make lint`: passing

Closes #94