### PR TITLE
feat: thread summarizer with institutional context

### DIFF
--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -17,6 +17,7 @@ from g3lobster.chat.auth import get_authenticated_service
 from g3lobster.chat.commands import detect_command, handle as handle_command
 from g3lobster.chat.debounce import DebounceKey, MessageDebouncer
 from g3lobster.chat.memory_inspector import build_memory_card, detect_memory_query
+from g3lobster.chat.thread_summarizer import ThreadSummarizer, detect_catchup_intent
 from g3lobster.cli.parser import get_content_id
 from g3lobster.cli.streaming import StreamEventType, accumulate_text
 from g3lobster.tasks.types import Task, TaskStatus
@@ -328,6 +329,13 @@ class ChatBridge:
         if detect_command(text) is not None and self.cron_store is not None:
             cmd_reply = await handle_command(text, target_id, self.cron_store, registry=self.registry, global_memory=getattr(self.registry, 'global_memory_manager', None))
             if cmd_reply is not None:
+                # Intercept __CATCHUP__ marker from /catchup command
+                if cmd_reply == "__CATCHUP__":
+                    user_id_safe = (sender.get("name") or "unknown")
+                    thread_id_safe = (thread_id or "no-thread").replace("/", "_")
+                    session_id = f"{self.space_id}__{user_id_safe}__{thread_id_safe}"
+                    await self._handle_catchup(persona, thread_id, session_id)
+                    return
                 if isinstance(cmd_reply, dict):
                     await self.send_message("", thread_id=thread_id, cards_v2=cmd_reply.get("cardsV2"))
                 else:
@@ -376,6 +384,12 @@ class ChatBridge:
         user_id = sender.get("name") or "unknown"
         thread_id_safe = (thread_id or "no-thread").replace("/", "_")
         session_id = f"{self.space_id}__{user_id}__{thread_id_safe}"
+
+        # Natural language catchup intent detection
+        if thread_id and detect_catchup_intent(merged_text):
+            await self._handle_catchup(persona, thread_id, session_id)
+            return
+
 
         task = Task(
             prompt=merged_text,
@@ -438,6 +452,68 @@ class ChatBridge:
                 reply_text += f"\n```\n{final_error}\n```"
         else:
             reply_text = f"{reply_persona.emoji} {reply_persona.name}: task finished with no output"
+
+        if thinking_name:
+            await self.update_message(thinking_name, reply_text)
+        else:
+            await self.send_message(reply_text, thread_id=thread_id)
+
+    async def _handle_catchup(
+        self,
+        persona,
+        thread_id: Optional[str],
+        session_id: str,
+    ) -> None:
+        """Handle a thread catch-up request via ThreadSummarizer."""
+        if not thread_id:
+            await self.send_message(
+                f"{persona.emoji} {persona.name}: Cannot summarize — no thread context.",
+                thread_id=thread_id,
+            )
+            return
+
+        thinking_msg = await self.send_message(
+            f"{persona.emoji} _{persona.name} is summarizing this thread..._",
+            thread_id=thread_id,
+        )
+        thinking_name: Optional[str] = thinking_msg.get("name") if thinking_msg else None
+
+        try:
+            # Build optional cross-reference engines
+            search_engine = None
+            data_dir = getattr(self.registry, "data_dir", None)
+            if data_dir:
+                from g3lobster.memory.search import MemorySearchEngine
+                search_engine = MemorySearchEngine(data_dir)
+
+            gmail_service = None
+            email_bridge = getattr(self.registry, "email_bridge", None)
+            if email_bridge and getattr(email_bridge, "service", None):
+                gmail_service = email_bridge.service
+
+            gemini_command = getattr(self.registry, "gemini_command", "gemini")
+            gemini_args = getattr(self.registry, "gemini_args", None)
+            gemini_timeout_s = getattr(self.registry, "gemini_timeout_s", 60.0)
+            gemini_cwd = getattr(self.registry, "gemini_cwd", None)
+
+            summarizer = ThreadSummarizer(
+                service=self.service,
+                search_engine=search_engine,
+                gmail_service=gmail_service,
+                gemini_command=gemini_command,
+                gemini_args=gemini_args,
+                gemini_timeout_s=gemini_timeout_s,
+                gemini_cwd=gemini_cwd,
+                agent_id=persona.id,
+            )
+
+            summary = await asyncio.to_thread(
+                summarizer.summarize, self.space_id, thread_id,
+            )
+            reply_text = f"{persona.emoji} {persona.name}:\n\n{summary}"
+        except Exception:
+            logger.exception("Thread summarization failed")
+            reply_text = f"{persona.emoji} {persona.name}: Sorry, thread summarization failed."
 
         if thinking_name:
             await self.update_message(thinking_name, reply_text)

--- a/g3lobster/chat/commands.py
+++ b/g3lobster/chat/commands.py
@@ -39,6 +39,7 @@ HELP_TEXT = """\
 • `/help` — show this message
 • `/status` — fleet dashboard showing all agents at a glance
 • `/quick` — show quick action buttons
+• `/catchup` — summarize this thread with cross-referenced context
 • `/cron list` — list scheduled tasks for this agent
 • `/cron add "<schedule>" "<instruction>"` — create a new cron task
   _schedule_: standard 5-field cron expression, e.g. `0 9 * * *`
@@ -58,7 +59,7 @@ HELP_TEXT = """\
 def detect_command(text: str) -> Optional[tuple[str, str]]:
     """Return ``(command, rest)`` if text contains a ``/`` command, else ``None``.
 
-    Recognised commands: ``help``, ``status``, ``quick``, ``teach``, ``cron``, ``sleep``, ``memory``, ``forget``.
+    Recognised commands: ``help``, ``status``, ``quick``, ``teach``, ``cron``, ``sleep``, ``memory``, ``forget``, ``catchup``.
     """
     m = _SLASH_RE.search(text)
     if not m:
@@ -109,6 +110,9 @@ async def handle(
 
     if cmd == "forget":
         return _handle_forget(rest, agent_id, registry)
+
+    if cmd == "catchup":
+        return "__CATCHUP__"
 
     # Unknown command — fall through to AI
     return None

--- a/g3lobster/chat/thread_summarizer.py
+++ b/g3lobster/chat/thread_summarizer.py
@@ -1,0 +1,406 @@
+"""Thread summarization with institutional context cross-referencing."""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from g3lobster.memory.search import MemorySearchEngine
+
+logger = logging.getLogger(__name__)
+
+# Natural language patterns for "catch me up" intent
+CATCHUP_INTENT_RE = re.compile(
+    r"catch\s+me\s+up|summarize\s+(?:this\s+)?thread|what\s+did\s+I\s+miss|"
+    r"tldr|tl;dr|what(?:'s| is| has)\s+(?:been\s+)?happening",
+    re.IGNORECASE,
+)
+
+# Max messages to include in a single summarization prompt to avoid exceeding context limits
+_MAX_PROMPT_MESSAGES = 80
+_CHUNK_SIZE = 40
+
+
+def detect_catchup_intent(text: str) -> bool:
+    """Return True if text expresses a 'catch me up' intent."""
+    return bool(CATCHUP_INTENT_RE.search(text))
+
+
+def fetch_thread_messages(
+    service: Any,
+    space_id: str,
+    thread_id: str,
+    page_size: int = 100,
+) -> List[Dict[str, Any]]:
+    """Fetch all messages in a thread from the Google Chat API.
+
+    Paginates through results to get the full thread history.
+    """
+    all_messages: List[Dict[str, Any]] = []
+    page_token: Optional[str] = None
+
+    while True:
+        kwargs: Dict[str, Any] = {
+            "parent": space_id,
+            "pageSize": page_size,
+            "filter": f'thread.name = "{thread_id}"',
+        }
+        if page_token:
+            kwargs["pageToken"] = page_token
+
+        response = service.spaces().messages().list(**kwargs).execute()
+        messages = response.get("messages", [])
+        all_messages.extend(messages)
+
+        page_token = response.get("nextPageToken")
+        if not page_token:
+            break
+
+    # Sort by createTime ascending
+    all_messages.sort(key=lambda m: m.get("createTime", ""))
+    return all_messages
+
+
+def extract_participants(messages: List[Dict[str, Any]]) -> List[Dict[str, str]]:
+    """Extract unique participants from thread messages.
+
+    Returns a list of dicts with 'name' and 'display_name' keys.
+    """
+    seen: Dict[str, Dict[str, str]] = {}
+    for msg in messages:
+        sender = msg.get("sender", {})
+        sender_name = sender.get("name", "")
+        display_name = sender.get("displayName", "")
+        if sender_name and sender_name not in seen:
+            seen[sender_name] = {
+                "name": sender_name,
+                "display_name": display_name,
+                "type": sender.get("type", "UNKNOWN"),
+            }
+    return list(seen.values())
+
+
+def search_related_memory(
+    search_engine: "MemorySearchEngine",
+    participants: List[Dict[str, str]],
+    topics: List[str],
+    agent_id: Optional[str] = None,
+    limit: int = 10,
+) -> List[Dict[str, str]]:
+    """Search agent memory for discussions related to participants and topics."""
+    hits: List[Dict[str, str]] = []
+    seen_snippets: set = set()
+
+    # Build search queries from topics and participant names
+    queries: List[str] = list(topics)
+    for p in participants:
+        display = p.get("display_name", "")
+        if display and display not in queries:
+            queries.append(display)
+
+    agent_ids = [agent_id] if agent_id else None
+
+    for query in queries[:5]:  # Limit to 5 queries to avoid excessive searching
+        try:
+            results = search_engine.search(
+                query,
+                agent_ids=agent_ids,
+                limit=limit,
+            )
+            for hit in results:
+                snippet_key = hit.snippet[:100]
+                if snippet_key not in seen_snippets:
+                    seen_snippets.add(snippet_key)
+                    hits.append({
+                        "source": hit.source,
+                        "snippet": hit.snippet,
+                        "memory_type": hit.memory_type,
+                    })
+        except Exception:
+            logger.debug("Memory search failed for query %r", query, exc_info=True)
+
+    return hits[:limit]
+
+
+def search_related_emails(
+    gmail_service: Any,
+    participants: List[Dict[str, str]],
+    limit: int = 5,
+) -> List[Dict[str, str]]:
+    """Search Gmail for recent threads involving the same participants.
+
+    Only called when an active Gmail service is available.
+    """
+    hits: List[Dict[str, str]] = []
+
+    # Build a Gmail search query from participant display names
+    human_participants = [
+        p["display_name"]
+        for p in participants
+        if p.get("type") == "HUMAN" and p.get("display_name")
+    ]
+    if not human_participants:
+        return hits
+
+    # Search for emails from/to participants (limit to first 3)
+    query_parts = [f"from:{name}" for name in human_participants[:3]]
+    query = " OR ".join(query_parts)
+
+    try:
+        response = gmail_service.users().messages().list(
+            userId="me", q=query, maxResults=limit,
+        ).execute()
+        for msg_stub in response.get("messages", []):
+            try:
+                msg = gmail_service.users().messages().get(
+                    userId="me", id=msg_stub["id"], format="metadata",
+                    metadataHeaders=["Subject", "From", "Date"],
+                ).execute()
+                headers = msg.get("payload", {}).get("headers", [])
+                subject = ""
+                sender = ""
+                for h in headers:
+                    if h.get("name", "").lower() == "subject":
+                        subject = h.get("value", "")
+                    elif h.get("name", "").lower() == "from":
+                        sender = h.get("value", "")
+                if subject:
+                    hits.append({
+                        "subject": subject,
+                        "from": sender,
+                        "snippet": msg.get("snippet", ""),
+                    })
+            except Exception:
+                logger.debug("Failed to fetch email %s", msg_stub["id"], exc_info=True)
+    except Exception:
+        logger.debug("Gmail search failed", exc_info=True)
+
+    return hits
+
+
+def _extract_topics(messages: List[Dict[str, Any]]) -> List[str]:
+    """Extract key topics from thread messages for memory cross-referencing."""
+    # Collect text from all messages, take first few words of each as topic hints
+    text_parts: List[str] = []
+    for msg in messages[:20]:  # Sample first 20 messages
+        text = (msg.get("text") or "").strip()
+        if text:
+            text_parts.append(text)
+
+    combined = " ".join(text_parts)
+    # Extract capitalized phrases and repeated nouns as rough topic extraction
+    # Simple heuristic: words that appear multiple times
+    words = re.findall(r"\b[A-Za-z]{3,}\b", combined.lower())
+    word_counts: Dict[str, int] = {}
+    for w in words:
+        word_counts[w] = word_counts.get(w, 0) + 1
+
+    # Return top frequent words (excluding common stop words)
+    stop_words = {
+        "the", "and", "for", "are", "but", "not", "you", "all", "can",
+        "had", "her", "was", "one", "our", "out", "has", "have", "been",
+        "this", "that", "with", "they", "from", "will", "what", "when",
+        "where", "which", "their", "there", "would", "could", "should",
+        "about", "just", "like", "also", "into", "than", "then", "them",
+        "some", "very", "does", "did", "how", "its", "let", "may",
+    }
+    topics = sorted(
+        ((w, c) for w, c in word_counts.items() if w not in stop_words and c >= 2),
+        key=lambda x: x[1],
+        reverse=True,
+    )
+    return [w for w, _ in topics[:10]]
+
+
+def _format_thread_for_prompt(messages: List[Dict[str, Any]]) -> str:
+    """Format thread messages into a compact transcript for the summarization prompt."""
+    lines: List[str] = []
+    for msg in messages:
+        sender = msg.get("sender", {})
+        display = sender.get("displayName", sender.get("name", "unknown"))
+        text = (msg.get("text") or "").strip()
+        if not text:
+            continue
+        create_time = (msg.get("createTime") or "")[:19].replace("T", " ")
+        # Truncate very long messages
+        if len(text) > 500:
+            text = text[:497] + "..."
+        lines.append(f"[{create_time}] {display}: {text}")
+    return "\n".join(lines)
+
+
+def _build_summary_prompt(
+    thread_text: str,
+    memory_hits: List[Dict[str, str]],
+    email_hits: List[Dict[str, str]],
+) -> str:
+    """Build the Gemini summarization prompt with cross-referenced context."""
+    parts: List[str] = [
+        "Summarize this Google Chat thread. Produce a structured summary with these sections:",
+        "- **Key Points**: The main topics and information discussed",
+        "- **Decisions**: Any decisions made or conclusions reached",
+        "- **Action Items**: Tasks assigned or next steps mentioned",
+        "- **Related Context**: Connections to past discussions or email threads (if any)",
+        "",
+        "Be concise. Use bullet points. Focus on what matters.",
+        "",
+        "## Thread Transcript",
+        thread_text,
+    ]
+
+    if memory_hits:
+        parts.append("")
+        parts.append("## Related Agent Memory")
+        for hit in memory_hits[:5]:
+            parts.append(f"- [{hit.get('memory_type', 'memory')}] {hit['snippet'][:200]}")
+
+    if email_hits:
+        parts.append("")
+        parts.append("## Related Email Threads")
+        for hit in email_hits[:3]:
+            parts.append(f"- Subject: {hit.get('subject', 'N/A')} (from: {hit.get('from', 'N/A')})")
+            snippet = hit.get("snippet", "")
+            if snippet:
+                parts.append(f"  Preview: {snippet[:150]}")
+
+    return "\n".join(parts)
+
+
+def _call_gemini(
+    prompt: str,
+    gemini_command: str = "gemini",
+    gemini_args: Optional[List[str]] = None,
+    timeout_s: float = 60.0,
+    cwd: Optional[str] = None,
+) -> str:
+    """Call Gemini CLI with the given prompt and return the response."""
+    args = gemini_args if gemini_args is not None else ["-y"]
+    command = [gemini_command, *args, "-p", prompt]
+    result = subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout_s,
+        cwd=cwd,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise RuntimeError(f"Gemini CLI exited with code {result.returncode}: {stderr}")
+    return (result.stdout or "").strip()
+
+
+def _chunk_messages(messages: List[Dict[str, Any]], chunk_size: int = _CHUNK_SIZE) -> List[List[Dict[str, Any]]]:
+    """Split messages into chunks for processing large threads."""
+    chunks: List[List[Dict[str, Any]]] = []
+    for i in range(0, len(messages), chunk_size):
+        chunks.append(messages[i : i + chunk_size])
+    return chunks
+
+
+class ThreadSummarizer:
+    """Orchestrates thread summarization with institutional context."""
+
+    def __init__(
+        self,
+        service: Any,
+        search_engine: Optional["MemorySearchEngine"] = None,
+        gmail_service: Any = None,
+        gemini_command: str = "gemini",
+        gemini_args: Optional[List[str]] = None,
+        gemini_timeout_s: float = 60.0,
+        gemini_cwd: Optional[str] = None,
+        agent_id: Optional[str] = None,
+    ):
+        self.service = service
+        self.search_engine = search_engine
+        self.gmail_service = gmail_service
+        self.gemini_command = gemini_command
+        self.gemini_args = gemini_args
+        self.gemini_timeout_s = gemini_timeout_s
+        self.gemini_cwd = gemini_cwd
+        self.agent_id = agent_id
+
+    def summarize(
+        self,
+        space_id: str,
+        thread_id: str,
+    ) -> str:
+        """Fetch thread, cross-reference context, and return structured summary."""
+        # 1. Fetch thread messages
+        messages = fetch_thread_messages(self.service, space_id, thread_id)
+        if not messages:
+            return "No messages found in this thread."
+
+        # 2. Extract participants and topics
+        participants = extract_participants(messages)
+        topics = _extract_topics(messages)
+
+        # 3. Cross-reference memory
+        memory_hits: List[Dict[str, str]] = []
+        if self.search_engine and topics:
+            memory_hits = search_related_memory(
+                self.search_engine,
+                participants,
+                topics,
+                agent_id=self.agent_id,
+            )
+
+        # 4. Cross-reference email (optional)
+        email_hits: List[Dict[str, str]] = []
+        if self.gmail_service and participants:
+            email_hits = search_related_emails(self.gmail_service, participants)
+
+        # 5. Build prompt and summarize
+        if len(messages) <= _MAX_PROMPT_MESSAGES:
+            thread_text = _format_thread_for_prompt(messages)
+            prompt = _build_summary_prompt(thread_text, memory_hits, email_hits)
+            return _call_gemini(
+                prompt,
+                gemini_command=self.gemini_command,
+                gemini_args=self.gemini_args,
+                timeout_s=self.gemini_timeout_s,
+                cwd=self.gemini_cwd,
+            )
+
+        # 6. Chunked summarization for long threads
+        chunks = _chunk_messages(messages)
+        chunk_summaries: List[str] = []
+        for i, chunk in enumerate(chunks):
+            chunk_text = _format_thread_for_prompt(chunk)
+            chunk_prompt = (
+                f"Summarize this part ({i + 1}/{len(chunks)}) of a Google Chat thread. "
+                "Return key points, decisions, and action items as bullet points.\n\n"
+                f"{chunk_text}"
+            )
+            try:
+                summary = _call_gemini(
+                    chunk_prompt,
+                    gemini_command=self.gemini_command,
+                    gemini_args=self.gemini_args,
+                    timeout_s=self.gemini_timeout_s,
+                    cwd=self.gemini_cwd,
+                )
+                chunk_summaries.append(summary)
+            except Exception:
+                logger.warning("Chunk %d/%d summarization failed", i + 1, len(chunks), exc_info=True)
+                chunk_summaries.append(f"(chunk {i + 1} summarization failed)")
+
+        # Final merge pass
+        merge_prompt = _build_summary_prompt(
+            "\n\n---\n\n".join(
+                f"## Part {i + 1}\n{s}" for i, s in enumerate(chunk_summaries)
+            ),
+            memory_hits,
+            email_hits,
+        )
+        return _call_gemini(
+            merge_prompt,
+            gemini_command=self.gemini_command,
+            gemini_args=self.gemini_args,
+            timeout_s=self.gemini_timeout_s,
+            cwd=self.gemini_cwd,
+        )

--- a/tests/test_thread_summarizer.py
+++ b/tests/test_thread_summarizer.py
@@ -1,0 +1,341 @@
+"""Tests for thread summarizer with institutional context."""
+
+from __future__ import annotations
+
+import pytest
+
+from g3lobster.chat.thread_summarizer import (
+    CATCHUP_INTENT_RE,
+    ThreadSummarizer,
+    _build_summary_prompt,
+    _extract_topics,
+    _format_thread_for_prompt,
+    detect_catchup_intent,
+    extract_participants,
+    fetch_thread_messages,
+    search_related_memory,
+)
+
+
+# ---------------------------------------------------------------------------
+# Intent detection
+# ---------------------------------------------------------------------------
+
+class TestDetectCatchupIntent:
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "catch me up",
+            "Catch me up on this thread",
+            "can you catch me up?",
+            "summarize this thread",
+            "summarize thread",
+            "what did I miss",
+            "What did I miss?",
+            "tldr",
+            "TLDR",
+            "tl;dr",
+            "TL;DR please",
+            "what's been happening",
+            "what is happening here",
+            "what has been happening",
+        ],
+    )
+    def test_positive_matches(self, text: str) -> None:
+        assert detect_catchup_intent(text) is True
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "hello",
+            "can you help me?",
+            "schedule a meeting",
+            "what's the weather",
+            "please do the task",
+            "",
+        ],
+    )
+    def test_negative_matches(self, text: str) -> None:
+        assert detect_catchup_intent(text) is False
+
+
+# ---------------------------------------------------------------------------
+# Participant extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractParticipants:
+    def test_extracts_unique_participants(self) -> None:
+        messages = [
+            {"sender": {"name": "users/1", "displayName": "Alice", "type": "HUMAN"}},
+            {"sender": {"name": "users/2", "displayName": "Bob", "type": "HUMAN"}},
+            {"sender": {"name": "users/1", "displayName": "Alice", "type": "HUMAN"}},
+            {"sender": {"name": "users/bot", "displayName": "Agent", "type": "BOT"}},
+        ]
+        participants = extract_participants(messages)
+        assert len(participants) == 3
+        names = {p["name"] for p in participants}
+        assert names == {"users/1", "users/2", "users/bot"}
+
+    def test_empty_messages(self) -> None:
+        assert extract_participants([]) == []
+
+    def test_missing_sender(self) -> None:
+        messages = [{"text": "hello"}, {"sender": {}}]
+        participants = extract_participants(messages)
+        assert len(participants) == 0
+
+
+# ---------------------------------------------------------------------------
+# Topic extraction
+# ---------------------------------------------------------------------------
+
+class TestExtractTopics:
+    def test_extracts_frequent_words(self) -> None:
+        messages = [
+            {"text": "We need to discuss the deployment pipeline"},
+            {"text": "The deployment is blocked by the pipeline issue"},
+            {"text": "Let's fix the pipeline today"},
+        ]
+        topics = _extract_topics(messages)
+        assert "pipeline" in topics
+        assert "deployment" in topics
+
+    def test_empty_messages(self) -> None:
+        assert _extract_topics([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Thread formatting
+# ---------------------------------------------------------------------------
+
+class TestFormatThread:
+    def test_formats_messages(self) -> None:
+        messages = [
+            {
+                "sender": {"displayName": "Alice"},
+                "text": "Hello team",
+                "createTime": "2025-01-15T10:00:00Z",
+            },
+            {
+                "sender": {"displayName": "Bob"},
+                "text": "Hi Alice",
+                "createTime": "2025-01-15T10:01:00Z",
+            },
+        ]
+        result = _format_thread_for_prompt(messages)
+        assert "Alice: Hello team" in result
+        assert "Bob: Hi Alice" in result
+
+    def test_skips_empty_text(self) -> None:
+        messages = [
+            {"sender": {"displayName": "Alice"}, "text": "", "createTime": "2025-01-15T10:00:00Z"},
+            {"sender": {"displayName": "Bob"}, "text": "Hi", "createTime": "2025-01-15T10:01:00Z"},
+        ]
+        result = _format_thread_for_prompt(messages)
+        assert "Alice" not in result
+        assert "Bob: Hi" in result
+
+    def test_truncates_long_messages(self) -> None:
+        messages = [
+            {
+                "sender": {"displayName": "Alice"},
+                "text": "x" * 600,
+                "createTime": "2025-01-15T10:00:00Z",
+            },
+        ]
+        result = _format_thread_for_prompt(messages)
+        assert len(result) < 600
+        assert "..." in result
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+class TestBuildSummaryPrompt:
+    def test_basic_prompt(self) -> None:
+        prompt = _build_summary_prompt("thread text here", [], [])
+        assert "Key Points" in prompt
+        assert "Decisions" in prompt
+        assert "Action Items" in prompt
+        assert "thread text here" in prompt
+
+    def test_with_memory_hits(self) -> None:
+        memory_hits = [
+            {"source": "memory.md", "snippet": "discussed deployment last week", "memory_type": "memory"},
+        ]
+        prompt = _build_summary_prompt("thread", memory_hits, [])
+        assert "Related Agent Memory" in prompt
+        assert "discussed deployment last week" in prompt
+
+    def test_with_email_hits(self) -> None:
+        email_hits = [
+            {"subject": "Deployment Plan", "from": "alice@example.com", "snippet": "Here is the plan"},
+        ]
+        prompt = _build_summary_prompt("thread", [], email_hits)
+        assert "Related Email Threads" in prompt
+        assert "Deployment Plan" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Memory search integration
+# ---------------------------------------------------------------------------
+
+class FakeSearchHit:
+    def __init__(self, snippet: str, source: str = "test.md", memory_type: str = "memory"):
+        self.snippet = snippet
+        self.source = source
+        self.memory_type = memory_type
+
+
+class FakeSearchEngine:
+    def __init__(self, results=None):
+        self._results = results or []
+        self.queries: list[str] = []
+
+    def search(self, query, *, agent_ids=None, limit=20, **kwargs):
+        self.queries.append(query)
+        return self._results
+
+
+class TestSearchRelatedMemory:
+    def test_searches_topics_and_participants(self) -> None:
+        engine = FakeSearchEngine(results=[FakeSearchHit("found something")])
+        participants = [{"display_name": "Alice", "type": "HUMAN"}]
+        topics = ["deployment", "pipeline"]
+
+        hits = search_related_memory(engine, participants, topics)
+        assert len(hits) > 0
+        assert hits[0]["snippet"] == "found something"
+        # Should have searched for topics + participant name
+        assert "deployment" in engine.queries
+        assert "pipeline" in engine.queries
+        assert "Alice" in engine.queries
+
+    def test_deduplicates_results(self) -> None:
+        hit = FakeSearchHit("same snippet")
+        engine = FakeSearchEngine(results=[hit])
+        participants = [{"display_name": "Alice", "type": "HUMAN"}]
+        topics = ["deployment", "pipeline"]
+
+        hits = search_related_memory(engine, participants, topics)
+        # Even though multiple queries return the same hit, it should be deduplicated
+        assert len(hits) == 1
+
+    def test_empty_topics(self) -> None:
+        engine = FakeSearchEngine()
+        hits = search_related_memory(engine, [], [])
+        assert hits == []
+
+
+# ---------------------------------------------------------------------------
+# Fetch thread messages (mocked)
+# ---------------------------------------------------------------------------
+
+class FakeCall:
+    def __init__(self, result):
+        self._result = result
+
+    def execute(self):
+        return self._result
+
+
+class FakeMessagesAPI:
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self._call_index = 0
+
+    def list(self, **kwargs):
+        resp = self._responses[self._call_index] if self._call_index < len(self._responses) else {"messages": []}
+        self._call_index += 1
+        return FakeCall(resp)
+
+
+class FakeSpacesAPI:
+    def __init__(self, messages_api):
+        self._messages_api = messages_api
+
+    def messages(self):
+        return self._messages_api
+
+
+class FakeService:
+    def __init__(self, messages_api):
+        self._spaces = FakeSpacesAPI(messages_api)
+
+    def spaces(self):
+        return self._spaces
+
+
+class TestFetchThreadMessages:
+    def test_fetches_single_page(self) -> None:
+        messages_api = FakeMessagesAPI([
+            {
+                "messages": [
+                    {"text": "hello", "createTime": "2025-01-15T10:00:00Z", "thread": {"name": "t1"}},
+                    {"text": "world", "createTime": "2025-01-15T10:01:00Z", "thread": {"name": "t1"}},
+                ],
+            },
+        ])
+        service = FakeService(messages_api)
+        result = fetch_thread_messages(service, "spaces/test", "t1")
+        assert len(result) == 2
+        assert result[0]["text"] == "hello"
+        assert result[1]["text"] == "world"
+
+    def test_paginates(self) -> None:
+        messages_api = FakeMessagesAPI([
+            {"messages": [{"text": "p1", "createTime": "2025-01-15T10:00:00Z"}], "nextPageToken": "tok2"},
+            {"messages": [{"text": "p2", "createTime": "2025-01-15T10:01:00Z"}]},
+        ])
+        service = FakeService(messages_api)
+        result = fetch_thread_messages(service, "spaces/test", "t1")
+        assert len(result) == 2
+
+    def test_empty_thread(self) -> None:
+        messages_api = FakeMessagesAPI([{"messages": []}])
+        service = FakeService(messages_api)
+        result = fetch_thread_messages(service, "spaces/test", "t1")
+        assert result == []
+
+
+# ---------------------------------------------------------------------------
+# ThreadSummarizer integration (mocked Gemini)
+# ---------------------------------------------------------------------------
+
+class TestThreadSummarizerSummarize:
+    def test_returns_no_messages(self) -> None:
+        messages_api = FakeMessagesAPI([{"messages": []}])
+        service = FakeService(messages_api)
+        summarizer = ThreadSummarizer(service=service)
+        result = summarizer.summarize("spaces/test", "t1")
+        assert "No messages" in result
+
+    def test_summarize_calls_gemini(self, monkeypatch) -> None:
+        messages_api = FakeMessagesAPI([
+            {
+                "messages": [
+                    {
+                        "text": "Let's discuss the release",
+                        "createTime": "2025-01-15T10:00:00Z",
+                        "sender": {"name": "users/1", "displayName": "Alice", "type": "HUMAN"},
+                    },
+                ],
+            },
+        ])
+        service = FakeService(messages_api)
+
+        captured_prompts: list[str] = []
+
+        def fake_call_gemini(prompt, **kwargs):
+            captured_prompts.append(prompt)
+            return "**Key Points**\n- Discussed release"
+
+        import g3lobster.chat.thread_summarizer as ts_mod
+        monkeypatch.setattr(ts_mod, "_call_gemini", fake_call_gemini)
+
+        summarizer = ThreadSummarizer(service=service)
+        result = summarizer.summarize("spaces/test", "t1")
+        assert "Key Points" in result
+        assert len(captured_prompts) == 1
+        assert "release" in captured_prompts[0]


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #96.

Adds thread catch-up summarization that combines Google Chat thread history with institutional memory (agent memory, session transcripts, Gmail threads) — producing summaries qualitatively better than tools that only summarize the thread itself.

## Changes
- **New: `g3lobster/chat/thread_summarizer.py`** — Core orchestrator with `ThreadSummarizer` class, intent detection (`detect_catchup_intent`), paginated thread fetching, participant extraction, topic extraction, memory cross-referencing via `MemorySearchEngine`, Gmail cross-referencing, Gemini CLI summarization, and chunked summarization for long threads (80+ messages)
- **Modified: `g3lobster/chat/commands.py`** — Added `/catchup` slash command that returns `__CATCHUP__` marker, updated help text
- **Modified: `g3lobster/chat/bridge.py`** — Intercepts `__CATCHUP__` marker from `/catchup` command, adds natural language intent detection before AI routing (regex: "catch me up", "summarize thread", "what did I miss", "tldr", etc.), new `_handle_catchup()` method that instantiates `ThreadSummarizer` with available memory/email services
- **New: `tests/test_thread_summarizer.py`** — 39 unit tests covering intent detection, participant extraction, topic extraction, thread formatting, prompt building, memory search integration, thread message fetching (mocked), and end-to-end summarizer flow

## Verification
- `pytest tests/`: 187 passed, 2 skipped
- `pytest tests/test_thread_summarizer.py`: 39 passed

Closes #96