### PR TITLE
feat: incident response coordinator for Google Chat

### DIFF
--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Dict, Optional, Set
 
 if TYPE_CHECKING:
     from g3lobster.cron.store import CronStore
+    from g3lobster.incident.store import IncidentStore
 
 from g3lobster.chat.auth import get_authenticated_service
 from g3lobster.chat.commands import handle as handle_command
@@ -78,6 +79,7 @@ class ChatBridge:
         seen_content: Optional[Set[str]] = None,
         auth_data_dir: Optional[str] = None,
         cron_store: Optional["CronStore"] = None,
+        incident_store: Optional["IncidentStore"] = None,
         seen_content_max_size: int = 10_000,
         debug_mode: bool = False,
         agent_filter: Optional[Set[str]] = None,
@@ -89,6 +91,7 @@ class ChatBridge:
         self.spaces_config = Path(spaces_config or (Path.home() / ".gemini" / "chat_bridge_spaces.json"))
         self.auth_data_dir = auth_data_dir
         self.cron_store = cron_store
+        self.incident_store = incident_store
         self.debug_mode = debug_mode
 
         self.space_id = space_id
@@ -274,7 +277,7 @@ class ChatBridge:
 
         # Slash-command interception — handle locally without hitting the AI.
         if self.cron_store is not None:
-            cmd_reply = handle_command(text, target_id, self.cron_store)
+            cmd_reply = handle_command(text, target_id, self.cron_store, self.incident_store)
             if cmd_reply is not None:
                 await self.send_message(
                     f"{persona.emoji} {persona.name}: {cmd_reply}",

--- a/g3lobster/chat/commands.py
+++ b/g3lobster/chat/commands.py
@@ -13,6 +13,11 @@ Supported commands
 ``/cron delete <id>``                  — delete a cron task
 ``/cron enable <id>``                  — enable a disabled task
 ``/cron disable <id>``                 — disable a task without deleting it
+``/incident <title>``                  — declare a new incident
+``/incident status <update>``          — add a status update to the active incident
+``/incident assign <role> <@user>``    — assign an incident role
+``/incident action <description>``     — add an action item
+``/resolve [summary]``                 — resolve the active incident
 """
 
 from __future__ import annotations
@@ -23,6 +28,7 @@ from typing import TYPE_CHECKING, Optional
 
 if TYPE_CHECKING:
     from g3lobster.cron.store import CronStore
+    from g3lobster.incident.store import IncidentStore
 
 # Matches a leading slash command token anywhere after optional whitespace /
 # (handles both "/cron list" and "@robo /cron list" after the mention is stripped).
@@ -38,6 +44,11 @@ HELP_TEXT = """\
 • `/cron enable <id>` — enable a disabled task
 • `/cron disable <id>` — disable a task (keeps it)
 • `/sleep <seconds>` — put the agent to sleep for a duration
+• `/incident <title>` — declare a new incident
+• `/incident status <update>` — add a timeline status update
+• `/incident assign <role> <@user>` — assign an incident role
+• `/incident action <description>` — track an action item
+• `/resolve [summary]` — resolve the active incident and post summary
 """
 
 
@@ -54,7 +65,12 @@ def detect_command(text: str) -> Optional[tuple[str, str]]:
     return cmd, rest
 
 
-def handle(text: str, agent_id: str, cron_store: "CronStore") -> Optional[str]:
+def handle(
+    text: str,
+    agent_id: str,
+    cron_store: "CronStore",
+    incident_store: Optional["IncidentStore"] = None,
+) -> Optional[str]:
     """Intercept and handle a slash command.
 
     Returns a reply string when the command is handled, or ``None`` when
@@ -74,6 +90,12 @@ def handle(text: str, agent_id: str, cron_store: "CronStore") -> Optional[str]:
 
     if cmd == "sleep":
         return _handle_sleep(rest, agent_id)
+
+    if cmd == "incident" and incident_store is not None:
+        return _handle_incident(rest, agent_id, incident_store, cron_store)
+
+    if cmd == "resolve" and incident_store is not None:
+        return _handle_resolve(rest, agent_id, incident_store, cron_store)
 
     # Unknown command — fall through to AI
     return None
@@ -172,3 +194,129 @@ def _cron_toggle(task_id_prefix: str, agent_id: str, cron_store: "CronStore", *,
         verb = "enabled" if enabled else "disabled"
         return f"{'▶' if enabled else '⏸'} Task `{matched[0].id[:8]}` {verb}."
     return "Failed to update task."
+
+
+# ------------------------------------------------------------------
+# Incident commands
+# ------------------------------------------------------------------
+
+_INCIDENT_CRON_SCHEDULE = "*/15 * * * *"
+_INCIDENT_PROMPT_PREFIX = "__INCIDENT_PROMPT__"
+
+
+def _handle_incident(
+    args: str, agent_id: str, incident_store: "IncidentStore", cron_store: "CronStore",
+) -> str:
+    from g3lobster.incident.formatter import format_incident_card
+
+    parts = args.split(None, 1)
+    sub = parts[0].lower() if parts else ""
+    rest = parts[1] if len(parts) > 1 else ""
+
+    if sub == "status":
+        return _incident_status(rest, agent_id, incident_store)
+    if sub == "assign":
+        return _incident_assign(rest, agent_id, incident_store)
+    if sub == "action":
+        return _incident_action(rest, agent_id, incident_store)
+
+    # Default: create a new incident. The entire args string is the title.
+    title = args.strip()
+    if not title:
+        return (
+            "Usage:\n"
+            "• `/incident <title>` — declare a new incident\n"
+            "• `/incident status <update>` — add a status update\n"
+            "• `/incident assign <role> <@user>` — assign a role\n"
+            "• `/incident action <description>` — add an action item"
+        )
+
+    incident = incident_store.create(agent_id, title)
+
+    # Schedule periodic status prompts via cron
+    try:
+        cron_task = cron_store.add_task(
+            agent_id,
+            _INCIDENT_CRON_SCHEDULE,
+            f"{_INCIDENT_PROMPT_PREFIX}:{incident.id}",
+        )
+        incident.cron_task_id = cron_task.id
+        incident_store._save(agent_id, incident)
+    except Exception:
+        pass  # Non-fatal — incident still works without prompts
+
+    return f"🚨 *Incident declared*\n\n{format_incident_card(incident)}"
+
+
+def _incident_status(args: str, agent_id: str, incident_store: "IncidentStore") -> str:
+    content = args.strip()
+    if not content:
+        return "Usage: `/incident status <update>`"
+    incident = incident_store.get_active(agent_id)
+    if not incident:
+        return "No active incident. Start one with `/incident <title>`."
+    updated = incident_store.append_timeline(agent_id, incident.id, "user", content, "status")
+    if not updated:
+        return "Failed to update timeline."
+    open_actions = sum(1 for a in updated.actions if a.status == "open")
+    return f"✅ Timeline updated. {len(updated.timeline)} entries, {open_actions} open action items."
+
+
+def _incident_assign(args: str, agent_id: str, incident_store: "IncidentStore") -> str:
+    parts = args.split(None, 1)
+    if len(parts) < 2:
+        return "Usage: `/incident assign <role> <@user>`\nExample: `/incident assign commander @alice`"
+    role, user = parts[0], parts[1]
+    incident = incident_store.get_active(agent_id)
+    if not incident:
+        return "No active incident. Start one with `/incident <title>`."
+    updated = incident_store.add_role(agent_id, incident.id, role, user)
+    if not updated:
+        return "Failed to assign role."
+    if role.lower() == "commander":
+        incident_store.get(agent_id, incident.id)
+        # Update commander field separately
+        inc = incident_store.get(agent_id, incident.id)
+        if inc:
+            inc.commander = user
+            incident_store._save(agent_id, inc)
+    return f"✅ Role `{role}` assigned to {user}."
+
+
+def _incident_action(args: str, agent_id: str, incident_store: "IncidentStore") -> str:
+    description = args.strip()
+    if not description:
+        return "Usage: `/incident action <description>`"
+    incident = incident_store.get_active(agent_id)
+    if not incident:
+        return "No active incident. Start one with `/incident <title>`."
+    updated = incident_store.add_action(agent_id, incident.id, description)
+    if not updated:
+        return "Failed to add action item."
+    open_count = sum(1 for a in updated.actions if a.status == "open")
+    return f"✅ Action item added. {open_count} open / {len(updated.actions)} total."
+
+
+def _handle_resolve(
+    args: str, agent_id: str, incident_store: "IncidentStore", cron_store: "CronStore",
+) -> str:
+    from g3lobster.incident.formatter import format_resolution_summary
+
+    incident = incident_store.get_active(agent_id)
+    if not incident:
+        return "No active incident to resolve."
+
+    summary = args.strip()
+
+    # Remove the cron status prompt task
+    if incident.cron_task_id:
+        try:
+            cron_store.delete_task(agent_id, incident.cron_task_id)
+        except Exception:
+            pass
+
+    resolved = incident_store.resolve(agent_id, incident.id, summary)
+    if not resolved:
+        return "Failed to resolve incident."
+
+    return f"✅ *Incident resolved*\n\n{format_resolution_summary(resolved)}"

--- a/g3lobster/cron/manager.py
+++ b/g3lobster/cron/manager.py
@@ -10,23 +10,32 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from g3lobster.cron.store import CronRunRecord, CronStore
 from g3lobster.tasks.types import Task
 
 if TYPE_CHECKING:
     from g3lobster.agents.registry import AgentRegistry
+    from g3lobster.incident.store import IncidentStore
 
 logger = logging.getLogger(__name__)
+
+_INCIDENT_PROMPT_PREFIX = "__INCIDENT_PROMPT__"
 
 
 class CronManager:
     """Wraps APScheduler to run per-agent cron tasks."""
 
-    def __init__(self, cron_store: CronStore, registry: "AgentRegistry") -> None:
+    def __init__(
+        self,
+        cron_store: CronStore,
+        registry: "AgentRegistry",
+        incident_store: Optional["IncidentStore"] = None,
+    ) -> None:
         self._store = cron_store
         self._registry = registry
+        self._incident_store = incident_store
         self._scheduler = None  # initialised lazily to avoid import-time dependency
 
     def _get_scheduler(self):
@@ -101,6 +110,27 @@ class CronManager:
         logger.info("Firing cron task %s for agent %s", task_id, agent_id)
         now = datetime.now(tz=timezone.utc).isoformat()
         self._store.update_task(agent_id, task_id, last_run=now)
+
+        # Handle __INCIDENT_PROMPT__ tasks — rewrite instruction to a status prompt.
+        if instruction.startswith(_INCIDENT_PROMPT_PREFIX) and self._incident_store:
+            incident_id = instruction[len(_INCIDENT_PROMPT_PREFIX) + 1:]
+            incident = self._incident_store.get(agent_id, incident_id)
+            if not incident:
+                # Incident was deleted or resolved; auto-clean the cron task.
+                self._store.delete_task(agent_id, task_id)
+                return
+            from g3lobster.incident.model import IncidentStatus
+            if incident.status != IncidentStatus.ACTIVE:
+                self._store.delete_task(agent_id, task_id)
+                return
+            from g3lobster.incident.formatter import format_status_prompt
+            last_ts = incident.timeline[-1].timestamp if incident.timeline else incident.created_at
+            try:
+                last_dt = datetime.fromisoformat(last_ts)
+                minutes = int((datetime.now(tz=timezone.utc) - last_dt).total_seconds() / 60)
+            except (ValueError, TypeError):
+                minutes = 15
+            instruction = format_status_prompt(incident, minutes)
 
         runtime = self._registry.get_agent(agent_id)
         if not runtime:

--- a/g3lobster/incident/__init__.py
+++ b/g3lobster/incident/__init__.py
@@ -1,0 +1,1 @@
+"""Incident response coordination for Google Chat."""

--- a/g3lobster/incident/formatter.py
+++ b/g3lobster/incident/formatter.py
@@ -1,0 +1,132 @@
+"""Text formatting functions for incident cards and summaries (Google Chat markdown)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Optional
+
+from g3lobster.incident.model import Incident, IncidentSeverity
+
+_SEVERITY_EMOJI = {
+    IncidentSeverity.SEV1: "🚨",
+    IncidentSeverity.SEV2: "🔴",
+    IncidentSeverity.SEV3: "🟡",
+    IncidentSeverity.SEV4: "🔵",
+}
+
+
+def _parse_iso(ts: str) -> Optional[datetime]:
+    """Return a timezone-aware datetime from an ISO 8601 string, or None."""
+    if not ts:
+        return None
+    try:
+        dt = datetime.fromisoformat(ts)
+        if dt.tzinfo is None:
+            dt = dt.replace(tzinfo=timezone.utc)
+        return dt
+    except ValueError:
+        return None
+
+
+def _hhmm(ts: str) -> str:
+    """Return HH:MM from an ISO 8601 timestamp, or the raw string on failure."""
+    dt = _parse_iso(ts)
+    return dt.strftime("%H:%M") if dt else ts
+
+
+def format_incident_card(incident: Incident) -> str:
+    """Create a structured text card for an incident."""
+    emoji = _SEVERITY_EMOJI.get(incident.severity, "")
+    severity_label = incident.severity.value.upper()
+    lines = [
+        f"{emoji} *[{severity_label}] {incident.title}*",
+        f"*Status:* {incident.status.value.capitalize()}",
+    ]
+
+    if incident.commander:
+        lines.append(f"*Commander:* {incident.commander}")
+
+    if incident.roles:
+        roles_str = ", ".join(f"{role}: {person}" for role, person in incident.roles.items())
+        lines.append(f"*Roles:* {roles_str}")
+
+    lines.append(f"*Timeline entries:* {len(incident.timeline)}")
+
+    open_count = sum(1 for a in incident.actions if a.status == "open")
+    total_count = len(incident.actions)
+    lines.append(f"*Action items:* {open_count} open / {total_count} total")
+
+    if incident.created_at:
+        lines.append(f"*Created at:* {incident.created_at}")
+
+    return "\n".join(lines)
+
+
+def format_timeline(incident: Incident) -> str:
+    """Render a chronological timeline of all entries."""
+    if not incident.timeline:
+        return f"*Timeline for '{incident.title}'*\n_(no entries yet)_"
+
+    header = f"*Timeline for '{incident.title}'*"
+    entries = [
+        f"[{_hhmm(e.timestamp)}] ({e.entry_type}) {e.author}: {e.content}"
+        for e in incident.timeline
+    ]
+    return header + "\n" + "\n".join(entries)
+
+
+def format_resolution_summary(incident: Incident) -> str:
+    """Produce a full post-mortem summary for a resolved incident."""
+    emoji = _SEVERITY_EMOJI.get(incident.severity, "")
+    severity_label = incident.severity.value.upper()
+    lines = [f"{emoji} *[{severity_label}] Resolution Summary: {incident.title}*", ""]
+
+    # Duration
+    created = _parse_iso(incident.created_at)
+    resolved = _parse_iso(incident.resolved_at or "")
+    if created and resolved:
+        delta = resolved - created
+        total_minutes = int(delta.total_seconds() // 60)
+        hours, minutes = divmod(total_minutes, 60)
+        duration_str = f"{hours}h {minutes}m" if hours else f"{minutes}m"
+        lines.append(f"*Duration:* {duration_str}  ({incident.created_at} → {incident.resolved_at})")
+    elif created:
+        lines.append(f"*Created at:* {incident.created_at}")
+
+    # Timeline
+    lines.append("")
+    lines.append("*Timeline*")
+    if incident.timeline:
+        for e in incident.timeline:
+            lines.append(f"[{_hhmm(e.timestamp)}] ({e.entry_type}) {e.author}: {e.content}")
+    else:
+        lines.append("_(no entries)_")
+
+    # Action items
+    lines.append("")
+    lines.append("*Action Items*")
+    if incident.actions:
+        for a in incident.actions:
+            status_icon = "✅" if a.status == "done" else "⬜"
+            assignee_part = f" — {a.assignee}" if a.assignee else ""
+            lines.append(f"{status_icon} {a.description}{assignee_part}")
+    else:
+        lines.append("_(none)_")
+
+    # Summary text (last timeline entry of type "note" or a dedicated field if added later)
+    summary_entries = [e for e in incident.timeline if e.entry_type == "note"]
+    if summary_entries:
+        lines.append("")
+        lines.append("*Summary*")
+        lines.append(summary_entries[-1].content)
+
+    return "\n".join(lines)
+
+
+def format_status_prompt(incident: Incident, minutes_since_last: int) -> str:
+    """Return a prompt asking the commander for a status update."""
+    return (
+        f"⏰ Active incident: '{incident.title}' — "
+        f"last update was {minutes_since_last} minutes ago. "
+        "Please provide a status update."
+    )

--- a/g3lobster/incident/model.py
+++ b/g3lobster/incident/model.py
@@ -1,0 +1,58 @@
+"""Incident data model — status, severity, timeline, and action items."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Dict, List, Optional
+
+
+class IncidentStatus(Enum):
+    ACTIVE = "active"
+    MITIGATED = "mitigated"
+    RESOLVED = "resolved"
+
+
+class IncidentSeverity(Enum):
+    SEV1 = "sev1"
+    SEV2 = "sev2"
+    SEV3 = "sev3"
+    SEV4 = "sev4"
+
+    @classmethod
+    def from_str(cls, s: str) -> "IncidentSeverity":
+        return cls(s.lower()) if s.lower() in {m.value for m in cls} else cls.SEV3
+
+
+@dataclass
+class TimelineEntry:
+    timestamp: str  # ISO 8601
+    author: str
+    content: str
+    entry_type: str  # "status", "action", "note"
+
+
+@dataclass
+class ActionItem:
+    id: str
+    description: str
+    assignee: str = ""
+    status: str = "open"  # "open" or "done"
+    created_at: str = ""  # ISO 8601
+
+
+@dataclass
+class Incident:
+    id: str
+    title: str
+    severity: IncidentSeverity = IncidentSeverity.SEV3
+    status: IncidentStatus = IncidentStatus.ACTIVE
+    commander: str = ""
+    roles: Dict[str, str] = field(default_factory=dict)
+    timeline: List[TimelineEntry] = field(default_factory=list)
+    actions: List[ActionItem] = field(default_factory=list)
+    created_at: str = ""  # ISO 8601
+    resolved_at: Optional[str] = None
+    thread_id: str = ""
+    space_id: str = ""
+    cron_task_id: Optional[str] = None

--- a/g3lobster/incident/store.py
+++ b/g3lobster/incident/store.py
@@ -1,0 +1,311 @@
+"""File-based incident storage.
+
+Incidents are persisted as JSON at ``{data_dir}/{agent_id}/incidents/{incident_id}.json``.
+The active incident pointer is stored at ``{data_dir}/{agent_id}/active_incident.json``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import tempfile
+import uuid
+from dataclasses import asdict
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional
+
+from g3lobster.incident.model import (
+    ActionItem,
+    Incident,
+    IncidentSeverity,
+    IncidentStatus,
+    TimelineEntry,
+)
+
+_ID_RE = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _safe_agent_id(agent_id: str) -> str:
+    """Validate agent_id is filesystem-safe (no path traversal)."""
+    safe = agent_id.strip()
+    if not safe or not _ID_RE.match(safe):
+        raise ValueError(f"Invalid agent_id: {agent_id!r}")
+    return safe
+
+
+def _now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
+
+
+def _incident_from_dict(data: dict) -> Incident:
+    """Reconstruct an Incident from a plain dict (as read from JSON)."""
+    d = {k: v for k, v in data.items() if k in Incident.__dataclass_fields__}
+    # Reconstruct nested objects
+    d["status"] = IncidentStatus(d["status"]) if "status" in d else IncidentStatus.ACTIVE
+    d["severity"] = IncidentSeverity(d["severity"]) if "severity" in d else IncidentSeverity.SEV3
+    d["timeline"] = [
+        TimelineEntry(**{k: v for k, v in entry.items() if k in TimelineEntry.__dataclass_fields__})
+        for entry in d.get("timeline", [])
+        if isinstance(entry, dict)
+    ]
+    d["actions"] = [
+        ActionItem(**{k: v for k, v in item.items() if k in ActionItem.__dataclass_fields__})
+        for item in d.get("actions", [])
+        if isinstance(item, dict)
+    ]
+    return Incident(**d)
+
+
+def _serialize(incident: Incident) -> dict:
+    """Convert Incident to a JSON-serializable dict."""
+    d = asdict(incident)
+    d["status"] = incident.status.value
+    d["severity"] = incident.severity.value
+    return d
+
+
+class IncidentStore:
+    """CRUD store for per-agent incidents backed by local JSON files."""
+
+    def __init__(self, data_dir: str) -> None:
+        self._data_dir = Path(data_dir)
+
+    def _incidents_dir(self, agent_id: str) -> Path:
+        safe = _safe_agent_id(agent_id)
+        return self._data_dir / safe / "incidents"
+
+    def _active_file(self, agent_id: str) -> Path:
+        safe = _safe_agent_id(agent_id)
+        return self._data_dir / safe / "active_incident.json"
+
+    # ------------------------------------------------------------------
+    # Internal I/O helpers
+    # ------------------------------------------------------------------
+
+    def _save(self, agent_id: str, incident: Incident) -> None:
+        """Atomically write incident JSON to its file."""
+        incidents_dir = self._incidents_dir(agent_id)
+        incidents_dir.mkdir(parents=True, exist_ok=True)
+        path = incidents_dir / f"{incident.id}.json"
+        payload = json.dumps(_serialize(incident), indent=2, ensure_ascii=False)
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=incidents_dir,
+            prefix=f"{incident.id}.",
+            suffix=".tmp",
+            delete=False,
+        )
+        tmp_path = Path(tmp.name)
+        try:
+            with tmp:
+                tmp.write(payload + "\n")
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, path)
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
+            raise
+
+    def _write_active_pointer(self, agent_id: str, incident_id: Optional[str]) -> None:
+        """Atomically write (or clear) the active incident pointer."""
+        path = self._active_file(agent_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        payload = json.dumps(incident_id or "", ensure_ascii=False)
+        tmp = tempfile.NamedTemporaryFile(
+            mode="w",
+            encoding="utf-8",
+            dir=path.parent,
+            prefix=f"{path.name}.",
+            suffix=".tmp",
+            delete=False,
+        )
+        tmp_path = Path(tmp.name)
+        try:
+            with tmp:
+                tmp.write(payload + "\n")
+                tmp.flush()
+                os.fsync(tmp.fileno())
+            os.replace(tmp_path, path)
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink(missing_ok=True)
+            raise
+
+    def _read_incident_file(self, path: Path) -> Optional[Incident]:
+        try:
+            raw = json.loads(path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+        if not isinstance(raw, dict):
+            return None
+        try:
+            return _incident_from_dict(raw)
+        except (TypeError, KeyError, ValueError):
+            return None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def create(
+        self,
+        agent_id: str,
+        title: str,
+        thread_id: str = "",
+        space_id: str = "",
+    ) -> Incident:
+        """Create a new incident, set it as active, and return it."""
+        incident = Incident(
+            id=str(uuid.uuid4()),
+            title=title,
+            thread_id=thread_id,
+            space_id=space_id,
+            created_at=_now(),
+        )
+        self._save(agent_id, incident)
+        self._write_active_pointer(agent_id, incident.id)
+        return incident
+
+    def get(self, agent_id: str, incident_id: str) -> Optional[Incident]:
+        """Read a single incident by ID."""
+        path = self._incidents_dir(agent_id) / f"{incident_id}.json"
+        if not path.exists():
+            return None
+        return self._read_incident_file(path)
+
+    def get_active(self, agent_id: str) -> Optional[Incident]:
+        """Read the currently active incident via the pointer file."""
+        pointer = self._active_file(agent_id)
+        if not pointer.exists():
+            return None
+        try:
+            incident_id = json.loads(pointer.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            return None
+        if not incident_id:
+            return None
+        return self.get(agent_id, incident_id)
+
+    def append_timeline(
+        self,
+        agent_id: str,
+        incident_id: str,
+        author: str,
+        content: str,
+        entry_type: str = "status",
+    ) -> Optional[Incident]:
+        """Append a timeline entry, save, and return the updated incident."""
+        incident = self.get(agent_id, incident_id)
+        if incident is None:
+            return None
+        entry = TimelineEntry(
+            timestamp=_now(),
+            author=author,
+            content=content,
+            entry_type=entry_type,
+        )
+        incident.timeline.append(entry)
+        self._save(agent_id, incident)
+        return incident
+
+    def add_action(
+        self,
+        agent_id: str,
+        incident_id: str,
+        description: str,
+        assignee: str = "",
+    ) -> Optional[Incident]:
+        """Add an action item with a new uuid id."""
+        incident = self.get(agent_id, incident_id)
+        if incident is None:
+            return None
+        action = ActionItem(
+            id=str(uuid.uuid4()),
+            description=description,
+            assignee=assignee,
+            created_at=_now(),
+        )
+        incident.actions.append(action)
+        self._save(agent_id, incident)
+        return incident
+
+    def update_action(
+        self,
+        agent_id: str,
+        incident_id: str,
+        action_id: str,
+        status: str = "done",
+    ) -> Optional[Incident]:
+        """Mark an action item's status."""
+        incident = self.get(agent_id, incident_id)
+        if incident is None:
+            return None
+        for action in incident.actions:
+            if action.id == action_id:
+                action.status = status
+                self._save(agent_id, incident)
+                return incident
+        return None
+
+    def add_role(
+        self,
+        agent_id: str,
+        incident_id: str,
+        role: str,
+        user: str,
+    ) -> Optional[Incident]:
+        """Set a role in the incident's roles dict."""
+        incident = self.get(agent_id, incident_id)
+        if incident is None:
+            return None
+        incident.roles[role] = user
+        self._save(agent_id, incident)
+        return incident
+
+    def resolve(
+        self,
+        agent_id: str,
+        incident_id: str,
+        summary: str = "",
+    ) -> Optional[Incident]:
+        """Resolve the incident: set status, record timestamp, clear active pointer."""
+        incident = self.get(agent_id, incident_id)
+        if incident is None:
+            return None
+        incident.status = IncidentStatus.RESOLVED
+        incident.resolved_at = _now()
+        if summary:
+            entry = TimelineEntry(
+                timestamp=incident.resolved_at,
+                author="system",
+                content=summary,
+                entry_type="status",
+            )
+            incident.timeline.append(entry)
+        self._save(agent_id, incident)
+        # Clear active pointer if it points to this incident
+        active = self._active_file(agent_id)
+        if active.exists():
+            try:
+                current_id = json.loads(active.read_text(encoding="utf-8"))
+                if current_id == incident_id:
+                    self._write_active_pointer(agent_id, None)
+            except (json.JSONDecodeError, OSError):
+                pass
+        return incident
+
+    def list_incidents(self, agent_id: str) -> List[Incident]:
+        """List all incidents for the given agent."""
+        incidents_dir = self._incidents_dir(agent_id)
+        if not incidents_dir.exists():
+            return []
+        result: List[Incident] = []
+        for path in sorted(incidents_dir.glob("*.json")):
+            incident = self._read_incident_file(path)
+            if incident is not None:
+                result.append(incident)
+        return result

--- a/tests/test_incident.py
+++ b/tests/test_incident.py
@@ -1,0 +1,357 @@
+"""Tests for incident response lifecycle: create → status → action → assign → resolve."""
+
+from __future__ import annotations
+
+import pytest
+
+from g3lobster.incident.model import (
+    ActionItem,
+    Incident,
+    IncidentSeverity,
+    IncidentStatus,
+    TimelineEntry,
+)
+from g3lobster.incident.store import IncidentStore
+from g3lobster.incident.formatter import (
+    format_incident_card,
+    format_resolution_summary,
+    format_status_prompt,
+    format_timeline,
+)
+
+
+AGENT_ID = "test-agent"
+
+
+@pytest.fixture
+def store(tmp_path):
+    return IncidentStore(str(tmp_path / "data"))
+
+
+# ------------------------------------------------------------------
+# Store: create and get
+# ------------------------------------------------------------------
+
+
+def test_create_incident(store):
+    inc = store.create(AGENT_ID, "prod API latency spike")
+    assert inc.title == "prod API latency spike"
+    assert inc.status == IncidentStatus.ACTIVE
+    assert inc.severity == IncidentSeverity.SEV3
+    assert inc.created_at
+
+
+def test_get_active_incident(store):
+    inc = store.create(AGENT_ID, "outage")
+    active = store.get_active(AGENT_ID)
+    assert active is not None
+    assert active.id == inc.id
+
+
+def test_no_active_incident(store):
+    assert store.get_active(AGENT_ID) is None
+
+
+def test_get_by_id(store):
+    inc = store.create(AGENT_ID, "test")
+    fetched = store.get(AGENT_ID, inc.id)
+    assert fetched is not None
+    assert fetched.title == "test"
+
+
+# ------------------------------------------------------------------
+# Store: timeline
+# ------------------------------------------------------------------
+
+
+def test_append_timeline(store):
+    inc = store.create(AGENT_ID, "outage")
+    updated = store.append_timeline(AGENT_ID, inc.id, "alice", "services recovering", "status")
+    assert updated is not None
+    assert len(updated.timeline) == 1
+    assert updated.timeline[0].author == "alice"
+    assert updated.timeline[0].content == "services recovering"
+    assert updated.timeline[0].entry_type == "status"
+
+
+def test_append_multiple_timeline_entries(store):
+    inc = store.create(AGENT_ID, "outage")
+    store.append_timeline(AGENT_ID, inc.id, "alice", "investigating", "status")
+    store.append_timeline(AGENT_ID, inc.id, "bob", "found root cause", "note")
+    updated = store.get(AGENT_ID, inc.id)
+    assert len(updated.timeline) == 2
+
+
+# ------------------------------------------------------------------
+# Store: action items
+# ------------------------------------------------------------------
+
+
+def test_add_action(store):
+    inc = store.create(AGENT_ID, "outage")
+    updated = store.add_action(AGENT_ID, inc.id, "rollback deployment", "alice")
+    assert updated is not None
+    assert len(updated.actions) == 1
+    assert updated.actions[0].description == "rollback deployment"
+    assert updated.actions[0].assignee == "alice"
+    assert updated.actions[0].status == "open"
+
+
+def test_update_action(store):
+    inc = store.create(AGENT_ID, "outage")
+    updated = store.add_action(AGENT_ID, inc.id, "rollback")
+    action_id = updated.actions[0].id
+    resolved = store.update_action(AGENT_ID, inc.id, action_id, "done")
+    assert resolved is not None
+    assert resolved.actions[0].status == "done"
+
+
+# ------------------------------------------------------------------
+# Store: roles
+# ------------------------------------------------------------------
+
+
+def test_add_role(store):
+    inc = store.create(AGENT_ID, "outage")
+    updated = store.add_role(AGENT_ID, inc.id, "commander", "@alice")
+    assert updated is not None
+    assert updated.roles["commander"] == "@alice"
+
+
+# ------------------------------------------------------------------
+# Store: resolve
+# ------------------------------------------------------------------
+
+
+def test_resolve_incident(store):
+    inc = store.create(AGENT_ID, "outage")
+    store.append_timeline(AGENT_ID, inc.id, "alice", "investigating", "status")
+    store.add_action(AGENT_ID, inc.id, "rollback")
+
+    resolved = store.resolve(AGENT_ID, inc.id, "root cause was upstream provider")
+    assert resolved is not None
+    assert resolved.status == IncidentStatus.RESOLVED
+    assert resolved.resolved_at is not None
+    # Summary appended as timeline entry
+    assert any("root cause" in e.content for e in resolved.timeline)
+
+    # Active pointer should be cleared
+    assert store.get_active(AGENT_ID) is None
+
+
+def test_resolve_without_summary(store):
+    inc = store.create(AGENT_ID, "outage")
+    resolved = store.resolve(AGENT_ID, inc.id)
+    assert resolved is not None
+    assert resolved.status == IncidentStatus.RESOLVED
+
+
+# ------------------------------------------------------------------
+# Store: list
+# ------------------------------------------------------------------
+
+
+def test_list_incidents(store):
+    store.create(AGENT_ID, "incident 1")
+    store.create(AGENT_ID, "incident 2")
+    incidents = store.list_incidents(AGENT_ID)
+    assert len(incidents) == 2
+
+
+def test_list_empty(store):
+    assert store.list_incidents(AGENT_ID) == []
+
+
+# ------------------------------------------------------------------
+# Store: persistence across reads
+# ------------------------------------------------------------------
+
+
+def test_persistence(store):
+    inc = store.create(AGENT_ID, "outage")
+    store.append_timeline(AGENT_ID, inc.id, "alice", "investigating", "status")
+    store.add_action(AGENT_ID, inc.id, "rollback")
+    store.add_role(AGENT_ID, inc.id, "comms", "@bob")
+
+    # Re-read from disk
+    fetched = store.get(AGENT_ID, inc.id)
+    assert fetched is not None
+    assert len(fetched.timeline) == 1
+    assert len(fetched.actions) == 1
+    assert fetched.roles["comms"] == "@bob"
+    assert fetched.severity == IncidentSeverity.SEV3
+    assert fetched.status == IncidentStatus.ACTIVE
+
+
+# ------------------------------------------------------------------
+# Formatter
+# ------------------------------------------------------------------
+
+
+def test_format_incident_card():
+    inc = Incident(
+        id="abc",
+        title="prod API latency",
+        severity=IncidentSeverity.SEV2,
+        created_at="2026-03-11T10:00:00+00:00",
+    )
+    card = format_incident_card(inc)
+    assert "prod API latency" in card
+    assert "SEV2" in card
+    assert "Active" in card
+
+
+def test_format_timeline():
+    inc = Incident(
+        id="abc",
+        title="outage",
+        timeline=[
+            TimelineEntry(timestamp="2026-03-11T10:00:00+00:00", author="alice", content="investigating", entry_type="status"),
+            TimelineEntry(timestamp="2026-03-11T10:15:00+00:00", author="bob", content="found cause", entry_type="note"),
+        ],
+    )
+    text = format_timeline(inc)
+    assert "10:00" in text
+    assert "alice" in text
+    assert "bob" in text
+
+
+def test_format_resolution_summary():
+    inc = Incident(
+        id="abc",
+        title="outage",
+        severity=IncidentSeverity.SEV1,
+        status=IncidentStatus.RESOLVED,
+        created_at="2026-03-11T10:00:00+00:00",
+        resolved_at="2026-03-11T11:30:00+00:00",
+        timeline=[
+            TimelineEntry(timestamp="2026-03-11T10:00:00+00:00", author="alice", content="started", entry_type="status"),
+        ],
+        actions=[
+            ActionItem(id="a1", description="rollback", status="done", created_at="2026-03-11T10:05:00+00:00"),
+            ActionItem(id="a2", description="investigate root cause", status="open", created_at="2026-03-11T10:10:00+00:00"),
+        ],
+    )
+    text = format_resolution_summary(inc)
+    assert "Resolution Summary" in text
+    assert "1h 30m" in text
+    assert "rollback" in text
+
+
+def test_format_status_prompt():
+    inc = Incident(id="abc", title="prod outage")
+    text = format_status_prompt(inc, 14)
+    assert "14 minutes" in text
+    assert "prod outage" in text
+
+
+# ------------------------------------------------------------------
+# Command integration
+# ------------------------------------------------------------------
+
+
+def test_command_incident_create(tmp_path):
+    from g3lobster.cron.store import CronStore
+    from g3lobster.chat.commands import handle
+
+    cron_store = CronStore(str(tmp_path / "cron"))
+    incident_store = IncidentStore(str(tmp_path / "data"))
+
+    reply = handle("/incident prod API latency spike", AGENT_ID, cron_store, incident_store)
+    assert reply is not None
+    assert "Incident declared" in reply
+    assert "prod API latency spike" in reply
+
+    # Incident should be active
+    active = incident_store.get_active(AGENT_ID)
+    assert active is not None
+    assert active.title == "prod API latency spike"
+
+    # Cron task should be created
+    crons = cron_store.list_tasks(AGENT_ID)
+    assert len(crons) == 1
+    assert "__INCIDENT_PROMPT__" in crons[0].instruction
+
+
+def test_command_incident_status(tmp_path):
+    from g3lobster.cron.store import CronStore
+    from g3lobster.chat.commands import handle
+
+    cron_store = CronStore(str(tmp_path / "cron"))
+    incident_store = IncidentStore(str(tmp_path / "data"))
+
+    handle("/incident outage", AGENT_ID, cron_store, incident_store)
+    reply = handle("/incident status services recovering", AGENT_ID, cron_store, incident_store)
+    assert reply is not None
+    assert "Timeline updated" in reply
+
+
+def test_command_incident_action(tmp_path):
+    from g3lobster.cron.store import CronStore
+    from g3lobster.chat.commands import handle
+
+    cron_store = CronStore(str(tmp_path / "cron"))
+    incident_store = IncidentStore(str(tmp_path / "data"))
+
+    handle("/incident outage", AGENT_ID, cron_store, incident_store)
+    reply = handle("/incident action rollback deployment", AGENT_ID, cron_store, incident_store)
+    assert reply is not None
+    assert "Action item added" in reply
+
+
+def test_command_incident_assign(tmp_path):
+    from g3lobster.cron.store import CronStore
+    from g3lobster.chat.commands import handle
+
+    cron_store = CronStore(str(tmp_path / "cron"))
+    incident_store = IncidentStore(str(tmp_path / "data"))
+
+    handle("/incident outage", AGENT_ID, cron_store, incident_store)
+    reply = handle("/incident assign commander @alice", AGENT_ID, cron_store, incident_store)
+    assert reply is not None
+    assert "commander" in reply
+    assert "@alice" in reply
+
+
+def test_command_resolve(tmp_path):
+    from g3lobster.cron.store import CronStore
+    from g3lobster.chat.commands import handle
+
+    cron_store = CronStore(str(tmp_path / "cron"))
+    incident_store = IncidentStore(str(tmp_path / "data"))
+
+    handle("/incident outage", AGENT_ID, cron_store, incident_store)
+    reply = handle("/resolve root cause was upstream", AGENT_ID, cron_store, incident_store)
+    assert reply is not None
+    assert "Incident resolved" in reply
+    assert "Resolution Summary" in reply
+
+    # Active should be cleared
+    assert incident_store.get_active(AGENT_ID) is None
+
+    # Cron should be cleaned up
+    crons = cron_store.list_tasks(AGENT_ID)
+    assert len(crons) == 0
+
+
+def test_command_resolve_no_active(tmp_path):
+    from g3lobster.cron.store import CronStore
+    from g3lobster.chat.commands import handle
+
+    cron_store = CronStore(str(tmp_path / "cron"))
+    incident_store = IncidentStore(str(tmp_path / "data"))
+
+    reply = handle("/resolve", AGENT_ID, cron_store, incident_store)
+    assert reply is not None
+    assert "No active incident" in reply
+
+
+def test_command_help_includes_incident(tmp_path):
+    from g3lobster.cron.store import CronStore
+    from g3lobster.chat.commands import handle
+
+    cron_store = CronStore(str(tmp_path / "cron"))
+    reply = handle("/help", AGENT_ID, cron_store)
+    assert reply is not None
+    assert "/incident" in reply
+    assert "/resolve" in reply


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #95.

Adds a complete incident response coordinator that lets users declare, manage, and resolve incidents directly in Google Chat threads. The system integrates with the existing chat bridge, cron, and slash command subsystems to provide structured incident management with automated timeline tracking, periodic status prompts, and resolution summaries.

## Changes
- **`g3lobster/incident/model.py`** — Incident data model with `IncidentStatus`, `IncidentSeverity`, `TimelineEntry`, `ActionItem`, and `Incident` dataclasses
- **`g3lobster/incident/store.py`** — File-based persistence with atomic JSON writes, active incident pointer, and full CRUD API
- **`g3lobster/incident/formatter.py`** — Text formatters for incident cards, timelines, resolution summaries, and status prompts
- **`g3lobster/chat/commands.py`** — Added `/incident` (create/status/assign/action) and `/resolve` slash commands with help text
- **`g3lobster/chat/bridge.py`** — Passes `IncidentStore` to command handler
- **`g3lobster/cron/manager.py`** — Handles `__INCIDENT_PROMPT__` cron tasks for periodic status prompts
- **`tests/test_incident.py`** — 25 tests covering full incident lifecycle

## Verification
- `pytest tests/test_incident.py`: 25/25 passing

Closes #95