### PR TITLE
feat: markdown-to-Google-Chat formatter

### DIFF
--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 from g3lobster.chat.auth import get_authenticated_service
 from g3lobster.chat.commands import detect_command, handle as handle_command
 from g3lobster.chat.debounce import DebounceKey, MessageDebouncer
+from g3lobster.chat.formatter import format_for_google_chat
 from g3lobster.chat.memory_inspector import build_memory_card, detect_memory_query
 from g3lobster.cli.parser import get_content_id
 from g3lobster.cli.streaming import StreamEventType, accumulate_text
@@ -450,7 +451,7 @@ class ChatBridge:
         thread_id: Optional[str] = None,
         cards_v2: Optional[list] = None,
     ) -> dict:
-        body: Dict[str, object] = {"text": text}
+        body: Dict[str, object] = {"text": format_for_google_chat(text)}
         if thread_id:
             body["thread"] = {"name": thread_id}
         if cards_v2:
@@ -486,7 +487,7 @@ class ChatBridge:
         return result or {}
 
     async def update_message(self, message_name: str, text: str) -> None:
-        body = {"text": text}
+        body = {"text": format_for_google_chat(text)}
         try:
             await asyncio.to_thread(
                 self.service.spaces()

--- a/g3lobster/chat/formatter.py
+++ b/g3lobster/chat/formatter.py
@@ -1,0 +1,43 @@
+"""Convert standard markdown to Google Chat markup."""
+
+from __future__ import annotations
+
+import re
+
+
+def format_for_google_chat(text: str) -> str:
+    """Convert standard markdown to Google Chat's non-standard markup.
+
+    Google Chat uses:
+    - ``*text*`` for bold (not ``**text**``)
+    - ``~text~`` for strikethrough (not ``~~text~~``)
+    - ``<url|text>`` for links (not ``[text](url)``)
+    - No ``#`` headers — they render literally
+
+    Fenced code blocks (``` ... ```) are preserved without conversion.
+    """
+    parts: list[str] = []
+    # Split on fenced code blocks to avoid converting inside them.
+    segments = re.split(r"(```[\s\S]*?```)", text)
+
+    for i, segment in enumerate(segments):
+        if i % 2 == 1:
+            # Inside a fenced code block — keep as-is.
+            parts.append(segment)
+            continue
+
+        # Convert **bold** to *bold*
+        segment = re.sub(r"\*\*(.+?)\*\*", r"*\1*", segment)
+
+        # Convert ~~strike~~ to ~strike~
+        segment = re.sub(r"~~(.+?)~~", r"~\1~", segment)
+
+        # Convert [text](url) to <url|text>
+        segment = re.sub(r"\[([^\]]+)\]\(([^)]+)\)", r"<\2|\1>", segment)
+
+        # Strip headers (# Header -> *Header*)
+        segment = re.sub(r"^#{1,6}\s+(.+)$", r"*\1*", segment, flags=re.MULTILINE)
+
+        parts.append(segment)
+
+    return "".join(parts)

--- a/tests/test_formatter.py
+++ b/tests/test_formatter.py
@@ -1,0 +1,103 @@
+"""Tests for g3lobster.chat.formatter."""
+
+from __future__ import annotations
+
+import pytest
+
+from g3lobster.chat.formatter import format_for_google_chat
+
+
+class TestBoldConversion:
+    def test_double_asterisk_to_single(self):
+        assert format_for_google_chat("**bold**") == "*bold*"
+
+    def test_multiple_bold_segments(self):
+        assert format_for_google_chat("**a** and **b**") == "*a* and *b*"
+
+    def test_bold_within_sentence(self):
+        assert format_for_google_chat("this is **important** text") == "this is *important* text"
+
+
+class TestStrikethroughConversion:
+    def test_double_tilde_to_single(self):
+        assert format_for_google_chat("~~strike~~") == "~strike~"
+
+    def test_multiple_strikethroughs(self):
+        assert format_for_google_chat("~~a~~ and ~~b~~") == "~a~ and ~b~"
+
+
+class TestLinkConversion:
+    def test_markdown_link_to_google_chat(self):
+        assert format_for_google_chat("[click here](https://example.com)") == "<https://example.com|click here>"
+
+    def test_multiple_links(self):
+        result = format_for_google_chat("[a](https://a.com) and [b](https://b.com)")
+        assert result == "<https://a.com|a> and <https://b.com|b>"
+
+
+class TestHeaderConversion:
+    def test_h1(self):
+        assert format_for_google_chat("# Title") == "*Title*"
+
+    def test_h2(self):
+        assert format_for_google_chat("## Subtitle") == "*Subtitle*"
+
+    def test_h3(self):
+        assert format_for_google_chat("### Section") == "*Section*"
+
+    def test_h6(self):
+        assert format_for_google_chat("###### Deep") == "*Deep*"
+
+    def test_multiline_headers(self):
+        text = "# First\nsome text\n## Second"
+        expected = "*First*\nsome text\n*Second*"
+        assert format_for_google_chat(text) == expected
+
+
+class TestCombinedFormatting:
+    def test_bold_and_link(self):
+        text = "**Check** [this](https://example.com)"
+        expected = "*Check* <https://example.com|this>"
+        assert format_for_google_chat(text) == expected
+
+    def test_header_with_bold(self):
+        # Header conversion runs after bold conversion
+        text = "# **Important** Title"
+        result = format_for_google_chat(text)
+        assert "*Important*" in result
+
+    def test_all_conversions(self):
+        text = "# Heading\n**bold** ~~strike~~ [link](https://x.com)"
+        result = format_for_google_chat(text)
+        assert "*Heading*" in result
+        assert "*bold*" in result
+        assert "~strike~" in result
+        assert "<https://x.com|link>" in result
+
+
+class TestPassthrough:
+    def test_empty_string(self):
+        assert format_for_google_chat("") == ""
+
+    def test_plain_text(self):
+        assert format_for_google_chat("hello world") == "hello world"
+
+    def test_single_asterisk_preserved(self):
+        assert format_for_google_chat("*already italic*") == "*already italic*"
+
+
+class TestCodeBlockPreservation:
+    def test_fenced_code_not_converted(self):
+        text = "```\n**bold** [link](url)\n```"
+        assert format_for_google_chat(text) == text
+
+    def test_mixed_code_and_text(self):
+        text = "**bold** text\n```\n**not bold**\n```\n**also bold**"
+        result = format_for_google_chat(text)
+        assert result.startswith("*bold* text")
+        assert "**not bold**" in result
+        assert result.endswith("*also bold*")
+
+    def test_code_block_with_language(self):
+        text = "```python\nx = **y**\n```"
+        assert format_for_google_chat(text) == text


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #84.

Adds a `format_for_google_chat()` function that converts standard markdown to Google Chat's non-standard markup format. Google Chat uses single `*` for bold, `~` for strikethrough, `<url|text>` for links, and doesn't support `#` headers. The formatter is applied at the `send_message()` and `update_message()` boundary in `ChatBridge`, so all agent responses render correctly. Fenced code blocks are preserved without conversion.

## Changes
- Created `g3lobster/chat/formatter.py` with `format_for_google_chat()` — handles bold, strikethrough, link, and header conversions while preserving fenced code blocks
- Updated `g3lobster/chat/bridge.py` — integrated formatter in `send_message()` and `update_message()`
- Created `tests/test_formatter.py` — 21 unit tests covering all conversion rules, edge cases, passthrough, and code block preservation

## Verification
- `pytest tests/`: 169 passed, 2 skipped

Closes #84