### PR TITLE
feat: MessageDebouncer for rapid-fire Google Chat messages

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,7 @@ chat:
   poll_interval_s: 2
   concierge_enabled: true
   concierge_agent_id: concierge
+  debounce_window_ms: 2000
 server:
   host: 0.0.0.0
   port: 40000

--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
     from g3lobster.standup.orchestrator import StandupOrchestrator
 
 from g3lobster.chat.auth import get_authenticated_service
-from g3lobster.chat.commands import handle as handle_command
+from g3lobster.chat.commands import detect_command, handle as handle_command
+from g3lobster.chat.debounce import MessageDebouncer
 from g3lobster.cli.parser import get_content_id
 from g3lobster.cli.streaming import StreamEventType, accumulate_text
 from g3lobster.tasks.types import Task, TaskStatus
@@ -84,6 +85,7 @@ class ChatBridge:
         debug_mode: bool = False,
         agent_filter: Optional[Set[str]] = None,
         concierge_agent_id: Optional[str] = None,
+        debounce_window_ms: int = 2000,
     ):
         self.registry = registry
         self.poll_interval_s = poll_interval_s
@@ -102,6 +104,10 @@ class ChatBridge:
         self._last_message_time: Optional[str] = last_message_time
         self._seen_content: BoundedSet = BoundedSet(seen_content_max_size)
         self._agent_filter: Optional[Set[str]] = set(agent_filter) if agent_filter is not None else None
+        self._debouncer = MessageDebouncer(
+            window_s=debounce_window_ms / 1000.0,
+            flush_callback=self._dispatch_to_agent,
+        )
         if seen_content:
             for item in seen_content:
                 self._seen_content.add(item)
@@ -129,6 +135,7 @@ class ChatBridge:
         return bool(self._poll_task and not self._poll_task.done())
 
     async def stop(self) -> None:
+        self._debouncer.cancel_all()
         self._stop_event.set()
         if self._poll_task:
             self._poll_task.cancel()
@@ -302,8 +309,8 @@ class ChatBridge:
         thread_id_safe = (thread_id or "no-thread").replace("/", "_")
         session_id = f"{self.space_id}__{user_id}__{thread_id_safe}"
 
-        # Slash-command interception — handle locally without hitting the AI.
-        if self.cron_store is not None:
+        # Slash-command interception — bypass debounce and handle locally.
+        if detect_command(text) is not None and self.cron_store is not None:
             cmd_reply = await handle_command(text, target_id, self.cron_store, registry=self.registry)
             if cmd_reply is not None:
                 if isinstance(cmd_reply, dict):
@@ -325,8 +332,40 @@ class ChatBridge:
                     target_id, sender_name, sender_display, text,
                 )
 
+        # Route through debouncer — merges rapid-fire messages into one prompt.
+        space_key = self.space_id or ""
+        debounce_key = (space_key, user_id, thread_id or "no-thread")
+        await self._debouncer.add(
+            key=debounce_key,
+            message=message,
+            text=text,
+            persona=persona,
+            thread_id=thread_id,
+            target_id=target_id,
+            session_id=session_id,
+        )
+
+    async def _dispatch_to_agent(
+        self,
+        merged_text: str,
+        message: dict,
+        persona: object,
+        thread_id: Optional[str],
+        target_id: str,
+        session_id: str,
+    ) -> None:
+        """Send a (possibly merged) prompt to the target agent."""
+        runtime = self.registry.get_agent(target_id)
+        if not runtime:
+            started = await self.registry.start_agent(target_id)
+            if not started:
+                return
+            runtime = self.registry.get_agent(target_id)
+            if not runtime:
+                return
+
         task = Task(
-            prompt=text,
+            prompt=merged_text,
             session_id=session_id,
             timeout_s=_resolve_task_timeout_s(persona, self.registry),
         )

--- a/g3lobster/chat/debounce.py
+++ b/g3lobster/chat/debounce.py
@@ -1,0 +1,157 @@
+"""Message debouncer for rapid-fire Google Chat messages.
+
+Collects messages from the same user+thread within a configurable time window
+and flushes them as a single merged prompt to the agent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Key: (space_id, user_id, thread_id)
+DebounceKey = Tuple[str, str, str]
+
+# Max messages buffered per key to prevent unbounded memory growth.
+_MAX_BUFFER_SIZE = 50
+
+
+@dataclass
+class _PendingBatch:
+    """Accumulated messages waiting for the debounce window to expire."""
+
+    texts: List[str] = field(default_factory=list)
+    first_message: Optional[Dict[str, Any]] = None
+    persona: Any = None
+    thread_id: Optional[str] = None
+    target_id: Optional[str] = None
+    session_id: Optional[str] = None
+    timer: Optional[asyncio.TimerHandle] = None
+
+
+class MessageDebouncer:
+    """Buffers rapid-fire messages and flushes them as a single merged prompt.
+
+    Parameters
+    ----------
+    window_s:
+        Debounce window in seconds.  Messages arriving within this window
+        after the *last* message are merged.
+    flush_callback:
+        Async callable invoked when the window expires.  Signature::
+
+            async def callback(
+                merged_text: str,
+                message: dict,
+                persona: Any,
+                thread_id: str | None,
+                target_id: str,
+                session_id: str,
+            ) -> None
+    """
+
+    def __init__(
+        self,
+        window_s: float = 2.0,
+        flush_callback: Optional[
+            Callable[..., Coroutine[Any, Any, None]]
+        ] = None,
+    ) -> None:
+        self._window_s = window_s
+        self._flush_callback = flush_callback
+        self._pending: Dict[DebounceKey, _PendingBatch] = {}
+
+    async def add(
+        self,
+        key: DebounceKey,
+        message: Dict[str, Any],
+        text: str,
+        persona: Any,
+        thread_id: Optional[str],
+        target_id: str,
+        session_id: str,
+    ) -> None:
+        """Buffer a message.  Resets the debounce timer on each call.
+
+        When ``window_s <= 0`` the message is dispatched immediately (no
+        buffering), which is useful in tests and when debouncing is disabled.
+        """
+        if self._window_s <= 0:
+            # Bypass: dispatch immediately without buffering.
+            if self._flush_callback is not None:
+                await self._flush_callback(
+                    text, message, persona, thread_id, target_id, session_id,
+                )
+            return
+
+        batch = self._pending.get(key)
+        if batch is None:
+            batch = _PendingBatch()
+            self._pending[key] = batch
+
+        # Cancel existing timer so the window restarts.
+        if batch.timer is not None:
+            batch.timer.cancel()
+
+        # Store metadata from the first message in the batch.
+        if batch.first_message is None:
+            batch.first_message = message
+            batch.persona = persona
+            batch.thread_id = thread_id
+            batch.target_id = target_id
+            batch.session_id = session_id
+
+        if len(batch.texts) < _MAX_BUFFER_SIZE:
+            batch.texts.append(text)
+
+        loop = asyncio.get_running_loop()
+        batch.timer = loop.call_later(
+            self._window_s, self._schedule_flush, key
+        )
+
+    def _schedule_flush(self, key: DebounceKey) -> None:
+        """Schedule the async flush on the running event loop."""
+        asyncio.ensure_future(self._flush(key))
+
+    async def _flush(self, key: DebounceKey) -> None:
+        batch = self._pending.pop(key, None)
+        if batch is None or not batch.texts:
+            return
+
+        merged_text = "\n".join(batch.texts)
+        logger.info(
+            "Debounce flush: key=%s msgs=%d merged_len=%d",
+            key,
+            len(batch.texts),
+            len(merged_text),
+        )
+
+        if self._flush_callback is not None:
+            try:
+                await self._flush_callback(
+                    merged_text,
+                    batch.first_message,
+                    batch.persona,
+                    batch.thread_id,
+                    batch.target_id,
+                    batch.session_id,
+                )
+            except Exception:
+                logger.exception("Debounce flush callback error for key=%s", key)
+
+    def cancel(self, key: DebounceKey) -> None:
+        """Cancel a pending batch for the given key."""
+        batch = self._pending.pop(key, None)
+        if batch and batch.timer is not None:
+            batch.timer.cancel()
+
+    def cancel_all(self) -> None:
+        """Cancel all pending batches (for shutdown)."""
+        for batch in self._pending.values():
+            if batch.timer is not None:
+                batch.timer.cancel()
+        self._pending.clear()

--- a/g3lobster/config.py
+++ b/g3lobster/config.py
@@ -58,6 +58,7 @@ class ChatConfig:
     poll_interval_s: float = 2.0
     concierge_enabled: bool = False
     concierge_agent_id: str = "concierge"
+    debounce_window_ms: int = 2000
 
 
 @dataclass

--- a/g3lobster/main.py
+++ b/g3lobster/main.py
@@ -218,6 +218,7 @@ def build_runtime(config: AppConfig):
             debug_mode=config.debug_mode,
             agent_filter=agent_filter,
             concierge_agent_id=concierge_id,
+            debounce_window_ms=config.chat.debounce_window_ms,
         )
 
     bridge_manager = BridgeManager(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -161,6 +161,7 @@ async def test_chat_bridge_routes_to_named_agent_by_bot_user_id(tmp_path) -> Non
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -218,6 +219,7 @@ async def test_chat_bridge_session_key_is_space_and_user(tmp_path) -> None:
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     base_message = {
@@ -269,6 +271,7 @@ async def test_chat_bridge_ignores_unlinked_mentions(tmp_path) -> None:
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -314,6 +317,7 @@ async def test_debug_mode_shows_error_detail_in_chat(tmp_path) -> None:
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
         debug_mode=True,
+        debounce_window_ms=0,
     )
 
     message = {
@@ -363,6 +367,7 @@ async def test_debug_off_hides_error_code_block(tmp_path) -> None:
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
         debug_mode=False,
+        debounce_window_ms=0,
     )
 
     message = {
@@ -410,6 +415,7 @@ async def test_chat_bridge_updates_original_message_for_tool_use(tmp_path) -> No
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -479,6 +485,7 @@ async def test_chat_bridge_uses_task_error_when_stream_ends_silently(tmp_path) -
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -565,6 +572,7 @@ async def test_unmentioned_message_routes_to_concierge(tmp_path) -> None:
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
         concierge_agent_id="concierge",
+        debounce_window_ms=0,
     )
 
     message = {
@@ -618,6 +626,7 @@ async def test_unmentioned_message_dropped_when_concierge_disabled(tmp_path) -> 
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
         # concierge_agent_id not set (None by default)
     )
 
@@ -674,6 +683,7 @@ async def test_explicit_mention_still_routes_directly_with_concierge(tmp_path) -
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
         concierge_agent_id="concierge",
+        debounce_window_ms=0,
     )
 
     message = {

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -1,0 +1,209 @@
+"""Tests for g3lobster.chat.debounce.MessageDebouncer."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from g3lobster.chat.debounce import MessageDebouncer
+
+
+class _FakePersona:
+    def __init__(self, name: str = "bot") -> None:
+        self.name = name
+        self.emoji = "🤖"
+        self.id = name
+
+
+class _FlushRecord:
+    """Captures arguments from a single flush callback invocation."""
+
+    def __init__(
+        self,
+        merged_text: str,
+        message: Dict[str, Any],
+        persona: Any,
+        thread_id: Optional[str],
+        target_id: str,
+        session_id: str,
+    ) -> None:
+        self.merged_text = merged_text
+        self.message = message
+        self.persona = persona
+        self.thread_id = thread_id
+        self.target_id = target_id
+        self.session_id = session_id
+
+
+class _FlushCollector:
+    """Async callback that records every flush invocation."""
+
+    def __init__(self) -> None:
+        self.records: List[_FlushRecord] = []
+        self.flush_event = asyncio.Event()
+
+    async def __call__(
+        self,
+        merged_text: str,
+        message: Dict[str, Any],
+        persona: Any,
+        thread_id: Optional[str],
+        target_id: str,
+        session_id: str,
+    ) -> None:
+        self.records.append(
+            _FlushRecord(merged_text, message, persona, thread_id, target_id, session_id)
+        )
+        self.flush_event.set()
+
+
+def _make_msg(text: str = "hello") -> Dict[str, Any]:
+    return {"text": text, "sender": {"type": "HUMAN", "name": "users/123"}}
+
+
+KEY = ("spaces/abc", "users/123", "threads/1")
+
+
+@pytest.mark.asyncio
+async def test_single_message_passthrough():
+    """A single message should flush after the debounce window."""
+    collector = _FlushCollector()
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=collector)
+    persona = _FakePersona()
+    msg = _make_msg("hello")
+
+    await debouncer.add(KEY, msg, "hello", persona, "threads/1", "agent-1", "sess-1")
+
+    await asyncio.sleep(0.15)
+    assert len(collector.records) == 1
+    assert collector.records[0].merged_text == "hello"
+    assert collector.records[0].target_id == "agent-1"
+    assert collector.records[0].session_id == "sess-1"
+
+
+@pytest.mark.asyncio
+async def test_multi_message_merge():
+    """Multiple messages within the window should merge into one flush."""
+    collector = _FlushCollector()
+    debouncer = MessageDebouncer(window_s=0.1, flush_callback=collector)
+    persona = _FakePersona()
+
+    await debouncer.add(KEY, _make_msg("one"), "one", persona, "threads/1", "agent-1", "sess-1")
+    await asyncio.sleep(0.02)
+    await debouncer.add(KEY, _make_msg("two"), "two", persona, "threads/1", "agent-1", "sess-1")
+    await asyncio.sleep(0.02)
+    await debouncer.add(KEY, _make_msg("three"), "three", persona, "threads/1", "agent-1", "sess-1")
+
+    # Wait for debounce window to expire after last message
+    await asyncio.sleep(0.2)
+    assert len(collector.records) == 1
+    assert collector.records[0].merged_text == "one\ntwo\nthree"
+
+
+@pytest.mark.asyncio
+async def test_timer_reset_on_new_message():
+    """Each new message should reset the debounce timer."""
+    collector = _FlushCollector()
+    debouncer = MessageDebouncer(window_s=0.1, flush_callback=collector)
+    persona = _FakePersona()
+
+    await debouncer.add(KEY, _make_msg("a"), "a", persona, "threads/1", "agent-1", "sess-1")
+    await asyncio.sleep(0.07)  # almost at window
+    # Timer should reset, so no flush yet
+    await debouncer.add(KEY, _make_msg("b"), "b", persona, "threads/1", "agent-1", "sess-1")
+    await asyncio.sleep(0.07)
+    # Should not have flushed yet (only 0.07s since last message)
+    assert len(collector.records) == 0
+
+    # Now wait for it to flush
+    await asyncio.sleep(0.1)
+    assert len(collector.records) == 1
+    assert collector.records[0].merged_text == "a\nb"
+
+
+@pytest.mark.asyncio
+async def test_separate_keys_flush_independently():
+    """Different keys should accumulate and flush independently."""
+    collector = _FlushCollector()
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=collector)
+    persona = _FakePersona()
+
+    key_a = ("spaces/abc", "users/123", "threads/1")
+    key_b = ("spaces/abc", "users/456", "threads/2")
+
+    await debouncer.add(key_a, _make_msg("msg-a"), "msg-a", persona, "threads/1", "agent-1", "sess-a")
+    await debouncer.add(key_b, _make_msg("msg-b"), "msg-b", persona, "threads/2", "agent-1", "sess-b")
+
+    await asyncio.sleep(0.15)
+    assert len(collector.records) == 2
+    texts = {r.merged_text for r in collector.records}
+    assert texts == {"msg-a", "msg-b"}
+
+
+@pytest.mark.asyncio
+async def test_cancel_prevents_flush():
+    """Cancelling a key should prevent its flush."""
+    collector = _FlushCollector()
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=collector)
+    persona = _FakePersona()
+
+    await debouncer.add(KEY, _make_msg("hello"), "hello", persona, "threads/1", "agent-1", "sess-1")
+    debouncer.cancel(KEY)
+
+    await asyncio.sleep(0.15)
+    assert len(collector.records) == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_prevents_all_flushes():
+    """cancel_all should prevent all pending flushes."""
+    collector = _FlushCollector()
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=collector)
+    persona = _FakePersona()
+
+    key_a = ("spaces/abc", "users/123", "threads/1")
+    key_b = ("spaces/abc", "users/456", "threads/2")
+    await debouncer.add(key_a, _make_msg("a"), "a", persona, "threads/1", "agent-1", "sess-a")
+    await debouncer.add(key_b, _make_msg("b"), "b", persona, "threads/2", "agent-1", "sess-b")
+
+    debouncer.cancel_all()
+
+    await asyncio.sleep(0.15)
+    assert len(collector.records) == 0
+
+
+@pytest.mark.asyncio
+async def test_configurable_window():
+    """The debounce window should be configurable."""
+    collector = _FlushCollector()
+    # Very short window
+    debouncer = MessageDebouncer(window_s=0.02, flush_callback=collector)
+    persona = _FakePersona()
+
+    await debouncer.add(KEY, _make_msg("fast"), "fast", persona, "threads/1", "agent-1", "sess-1")
+    await asyncio.sleep(0.08)
+    assert len(collector.records) == 1
+    assert collector.records[0].merged_text == "fast"
+
+
+@pytest.mark.asyncio
+async def test_first_message_metadata_preserved():
+    """The first message's metadata should be used for the flush callback."""
+    collector = _FlushCollector()
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=collector)
+    persona_1 = _FakePersona("first")
+    persona_2 = _FakePersona("second")
+
+    first_msg = _make_msg("one")
+    second_msg = _make_msg("two")
+
+    await debouncer.add(KEY, first_msg, "one", persona_1, "threads/1", "agent-1", "sess-1")
+    await debouncer.add(KEY, second_msg, "two", persona_2, "threads/1", "agent-1", "sess-1")
+
+    await asyncio.sleep(0.15)
+    assert len(collector.records) == 1
+    # First message's metadata should be preserved
+    assert collector.records[0].message is first_msg
+    assert collector.records[0].persona is persona_1

--- a/tests/test_timeout_policy.py
+++ b/tests/test_timeout_policy.py
@@ -256,6 +256,7 @@ async def test_chat_bridge_uses_persona_response_timeout(tmp_path: Path) -> None
         space_id="spaces/test",
         service=_FakeService(),
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -294,6 +295,7 @@ async def test_chat_bridge_falls_back_to_registry_timeout(tmp_path: Path) -> Non
         space_id="spaces/test",
         service=_FakeService(),
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #70.

Adds a `MessageDebouncer` class that collects rapid-fire messages from the same user+thread within a configurable time window (default 2000ms) and flushes them as a single merged prompt to the agent. This eliminates redundant Gemini CLI invocations, prevents interleaved streaming responses, and avoids Google Chat API rate-limit contention when users send multiple messages in quick succession.

## Changes
- **`g3lobster/chat/debounce.py` (new)**: `MessageDebouncer` class with asyncio timer-based buffering, keyed by `(space_id, user_id, thread_id)`, bounded buffer, and cancel/cancel_all for cleanup
- **`g3lobster/config.py`**: Added `debounce_window_ms: int = 2000` to `ChatConfig`
- **`g3lobster/chat/bridge.py`**: Refactored `handle_message()` to route non-command messages through debouncer; extracted `_dispatch_to_agent()` method; slash commands bypass debounce via `detect_command()` check; debouncer cancelled on bridge stop
- **`g3lobster/main.py`**: Pass `debounce_window_ms` from config to `ChatBridge` factory
- **`config.yaml`**: Added `debounce_window_ms: 2000` to chat section
- **`tests/test_debounce.py` (new)**: 8 unit tests covering single message passthrough, multi-message merge, timer reset, independent keys, cancel, cancel_all, configurable window, and metadata preservation
- **`tests/test_chat.py`, `tests/test_timeout_policy.py`**: Updated existing tests with `debounce_window_ms=0` for synchronous dispatch

## Verification
- `pytest tests/test_debounce.py tests/test_chat.py tests/test_timeout_policy.py`: 27 passed
- Full test suite: 270 passed, 0 failed

Closes #70