### PR TITLE
fix(gammawave): complete concierge config persistence for #78

### DIFF
--- a/g3lobster/config.py
+++ b/g3lobster/config.py
@@ -296,6 +296,8 @@ def save_chat_config(chat: ChatConfig, config_path: str) -> None:
         "space_id": chat.space_id,
         "space_name": chat.space_name,
         "poll_interval_s": chat.poll_interval_s,
+        "concierge_enabled": chat.concierge_enabled,
+        "concierge_agent_id": chat.concierge_agent_id,
     }
 
     path.parent.mkdir(parents=True, exist_ok=True)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -695,3 +695,30 @@ async def test_explicit_mention_still_routes_directly_with_concierge(tmp_path) -
     assert "Concierge" not in service.messages_api.created[0]["body"]["text"]
     assert len(service.messages_api.updated) == 1
     assert "🦀 Luna: reply" in service.messages_api.updated[0]["body"]["text"]
+
+
+def test_save_chat_config_persists_concierge_fields(tmp_path) -> None:
+    """save_chat_config must round-trip the concierge_enabled and concierge_agent_id fields."""
+    from g3lobster.config import ChatConfig, save_chat_config
+
+    cfg = ChatConfig(
+        enabled=True,
+        space_id="spaces/abc",
+        space_name="Test Space",
+        poll_interval_s=3.0,
+        concierge_enabled=True,
+        concierge_agent_id="my-concierge",
+    )
+    config_path = str(tmp_path / "config.yaml")
+    save_chat_config(cfg, config_path)
+
+    import yaml
+
+    with open(config_path) as f:
+        saved = yaml.safe_load(f)
+
+    chat = saved["chat"]
+    assert chat["concierge_enabled"] is True
+    assert chat["concierge_agent_id"] == "my-concierge"
+    assert chat["enabled"] is True
+    assert chat["space_id"] == "spaces/abc"


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #78.

The concierge/router agent feature was already implemented and merged (PR #118, commit d41b358). This PR addresses two remaining gaps found during verification:

1. **`save_chat_config()` now persists concierge fields** — `concierge_enabled` and `concierge_agent_id` were missing from the YAML round-trip, causing them to be lost when config was saved at runtime.
2. **Added test for config persistence** — `test_save_chat_config_persists_concierge_fields` verifies the round-trip of all concierge config fields.

## Changes
- `g3lobster/config.py`: Added `concierge_enabled` and `concierge_agent_id` to the `save_chat_config()` payload dict
- `tests/test_chat.py`: Added `test_save_chat_config_persists_concierge_fields` test

## Verification
- `pytest tests/test_chat.py`: 11/11 passing

Closes #78