### PR TITLE
feat(gammawave): implement #70 — MessageDebouncer for Chat

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -26,6 +26,7 @@ chat:
   poll_interval_s: 2
   concierge_enabled: true
   concierge_agent_id: concierge
+  debounce_window_ms: 2000
 server:
   host: 0.0.0.0
   port: 40000

--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -14,7 +14,8 @@ if TYPE_CHECKING:
     from g3lobster.standup.orchestrator import StandupOrchestrator
 
 from g3lobster.chat.auth import get_authenticated_service
-from g3lobster.chat.commands import handle as handle_command
+from g3lobster.chat.commands import detect_command, handle as handle_command
+from g3lobster.chat.debounce import DebounceKey, MessageDebouncer
 from g3lobster.cli.parser import get_content_id
 from g3lobster.cli.streaming import StreamEventType, accumulate_text
 from g3lobster.tasks.types import Task, TaskStatus
@@ -84,6 +85,7 @@ class ChatBridge:
         debug_mode: bool = False,
         agent_filter: Optional[Set[str]] = None,
         concierge_agent_id: Optional[str] = None,
+        debounce_window_ms: int = 2000,
     ):
         self.registry = registry
         self.poll_interval_s = poll_interval_s
@@ -102,6 +104,10 @@ class ChatBridge:
         self._last_message_time: Optional[str] = last_message_time
         self._seen_content: BoundedSet = BoundedSet(seen_content_max_size)
         self._agent_filter: Optional[Set[str]] = set(agent_filter) if agent_filter is not None else None
+        self._debouncer = MessageDebouncer(
+            window_s=debounce_window_ms / 1000.0,
+            flush_callback=self._dispatch_to_agent,
+        )
         if seen_content:
             for item in seen_content:
                 self._seen_content.add(item)
@@ -130,6 +136,7 @@ class ChatBridge:
 
     async def stop(self) -> None:
         self._stop_event.set()
+        self._debouncer.cancel_all()
         if self._poll_task:
             self._poll_task.cancel()
             try:
@@ -299,15 +306,12 @@ class ChatBridge:
 
         thread_id = message.get("thread", {}).get("name")
         user_id = sender.get("name") or "unknown"
-        thread_id_safe = (thread_id or "no-thread").replace("/", "_")
-        session_id = f"{self.space_id}__{user_id}__{thread_id_safe}"
 
-        # Slash-command interception — handle locally without hitting the AI.
-        if self.cron_store is not None:
+        # Slash-command interception — handle immediately, bypass debounce.
+        if detect_command(text) is not None and self.cron_store is not None:
             cmd_reply = await handle_command(text, target_id, self.cron_store, registry=self.registry, global_memory=getattr(self.registry, 'global_memory_manager', None))
             if cmd_reply is not None:
                 if isinstance(cmd_reply, dict):
-                    # Cards v2 response (e.g. /status)
                     await self.send_message("", thread_id=thread_id, cards_v2=cmd_reply.get("cardsV2"))
                 else:
                     await self.send_message(
@@ -325,8 +329,39 @@ class ChatBridge:
                     target_id, sender_name, sender_display, text,
                 )
 
+        # Route through debouncer for non-command messages.
+        # When debounce window is zero, dispatch directly (no timer overhead).
+        if self._debouncer.window_s == 0:
+            await self._dispatch_to_agent(text, message, persona, thread_id, target_id)
+        else:
+            key: DebounceKey = (self.space_id or "", user_id, thread_id or "no-thread")
+            self._debouncer.add(key, text, message, persona, thread_id, target_id)
+
+    async def _dispatch_to_agent(
+        self,
+        merged_text: str,
+        message: dict,
+        persona: object,
+        thread_id: Optional[str],
+        target_id: str,
+    ) -> None:
+        """Flush callback — sends the (possibly merged) prompt to the agent."""
+        runtime = self.registry.get_agent(target_id)
+        if not runtime:
+            started = await self.registry.start_agent(target_id)
+            if not started:
+                return
+            runtime = self.registry.get_agent(target_id)
+            if not runtime:
+                return
+
+        sender = message.get("sender", {})
+        user_id = sender.get("name") or "unknown"
+        thread_id_safe = (thread_id or "no-thread").replace("/", "_")
+        session_id = f"{self.space_id}__{user_id}__{thread_id_safe}"
+
         task = Task(
-            prompt=text,
+            prompt=merged_text,
             session_id=session_id,
             timeout_s=_resolve_task_timeout_s(persona, self.registry),
         )
@@ -387,7 +422,6 @@ class ChatBridge:
         else:
             reply_text = f"{reply_persona.emoji} {reply_persona.name}: task finished with no output"
 
-        # Update the thinking message in-place (no extra new message).
         if thinking_name:
             await self.update_message(thinking_name, reply_text)
         else:

--- a/g3lobster/chat/debounce.py
+++ b/g3lobster/chat/debounce.py
@@ -1,0 +1,165 @@
+"""Message debouncer for Google Chat rapid-fire messages.
+
+Collects messages from the same (space, user, thread) tuple within a
+configurable time window, then flushes them as a single merged prompt.
+
+Slash commands bypass the debouncer entirely — they are detected and
+handled before messages reach ``add()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Callable, Coroutine, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Key: (space_id, user_id, thread_id)
+DebounceKey = Tuple[str, str, str]
+
+
+@dataclass
+class _PendingBurst:
+    """Accumulated messages waiting for the debounce timer to fire."""
+
+    texts: List[str] = field(default_factory=list)
+    first_message: Optional[Dict[str, Any]] = None
+    persona: Any = None
+    thread_id: Optional[str] = None
+    target_id: Optional[str] = None
+    timer: Optional[asyncio.TimerHandle] = None
+
+
+class MessageDebouncer:
+    """Debounce rapid-fire messages keyed by (space_id, user_id, thread_id).
+
+    Parameters
+    ----------
+    window_s:
+        Debounce window in seconds. Messages arriving within this window
+        of the most recent message are merged.
+    flush_callback:
+        Async callable invoked on timer expiry with the merged prompt and
+        first message's metadata:
+        ``flush_callback(merged_text, message, persona, thread_id, target_id)``
+    max_buffer_per_key:
+        Maximum number of messages to buffer per key (prevents unbounded
+        memory growth). Once reached, the buffer flushes immediately.
+    """
+
+    def __init__(
+        self,
+        window_s: float = 2.0,
+        flush_callback: Optional[
+            Callable[..., Coroutine[Any, Any, None]]
+        ] = None,
+        max_buffer_per_key: int = 50,
+    ) -> None:
+        if window_s < 0:
+            raise ValueError("window_s must be >= 0")
+        self._window_s = window_s
+        self._flush_callback = flush_callback
+        self._max_buffer = max_buffer_per_key
+        self._pending: Dict[DebounceKey, _PendingBurst] = {}
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    @property
+    def window_s(self) -> float:
+        return self._window_s
+
+    def _get_loop(self) -> asyncio.AbstractEventLoop:
+        if self._loop is None or self._loop.is_closed():
+            self._loop = asyncio.get_running_loop()
+        return self._loop
+
+    def add(
+        self,
+        key: DebounceKey,
+        text: str,
+        message: Dict[str, Any],
+        persona: Any,
+        thread_id: Optional[str],
+        target_id: str,
+    ) -> None:
+        """Buffer a message. Resets the debounce timer for *key*."""
+        burst = self._pending.get(key)
+        if burst is None:
+            burst = _PendingBurst()
+            self._pending[key] = burst
+
+        # Keep first message metadata for the flush callback
+        if burst.first_message is None:
+            burst.first_message = message
+            burst.persona = persona
+            burst.thread_id = thread_id
+            burst.target_id = target_id
+
+        burst.texts.append(text)
+
+        # Cancel existing timer and reset
+        if burst.timer is not None:
+            burst.timer.cancel()
+            burst.timer = None
+
+        # Flush immediately if buffer is full
+        if len(burst.texts) >= self._max_buffer:
+            self._schedule_flush(key, delay=0)
+            return
+
+        self._schedule_flush(key, delay=self._window_s)
+
+    def _schedule_flush(self, key: DebounceKey, delay: float) -> None:
+        loop = self._get_loop()
+        burst = self._pending.get(key)
+        if burst is None:
+            return
+        burst.timer = loop.call_later(delay, self._fire, key)
+
+    def _fire(self, key: DebounceKey) -> None:
+        """Timer callback — schedules the async flush as a task."""
+        burst = self._pending.pop(key, None)
+        if burst is None:
+            return
+        burst.timer = None
+
+        loop = self._get_loop()
+        loop.create_task(self._flush(key, burst))
+
+    async def _flush(self, key: DebounceKey, burst: _PendingBurst) -> None:
+        merged = "\n".join(burst.texts)
+        count = len(burst.texts)
+        if count > 1:
+            logger.info(
+                "Debounce: merged %d messages for %s", count, key,
+            )
+        if self._flush_callback is not None:
+            try:
+                await self._flush_callback(
+                    merged,
+                    burst.first_message,
+                    burst.persona,
+                    burst.thread_id,
+                    burst.target_id,
+                )
+            except Exception:
+                logger.exception("Debounce flush callback error for %s", key)
+
+    def cancel(self, key: DebounceKey) -> None:
+        """Cancel a pending debounce for *key* without flushing."""
+        burst = self._pending.pop(key, None)
+        if burst is not None and burst.timer is not None:
+            burst.timer.cancel()
+
+    def cancel_all(self) -> None:
+        """Cancel all pending debounce timers (for shutdown)."""
+        for burst in self._pending.values():
+            if burst.timer is not None:
+                burst.timer.cancel()
+        self._pending.clear()
+
+    @property
+    def pending_count(self) -> int:
+        """Number of keys currently waiting for flush."""
+        return len(self._pending)

--- a/g3lobster/config.py
+++ b/g3lobster/config.py
@@ -60,6 +60,7 @@ class ChatConfig:
     poll_interval_s: float = 2.0
     concierge_enabled: bool = False
     concierge_agent_id: str = "concierge"
+    debounce_window_ms: int = 2000
 
 
 @dataclass

--- a/g3lobster/main.py
+++ b/g3lobster/main.py
@@ -218,6 +218,7 @@ def build_runtime(config: AppConfig):
             debug_mode=config.debug_mode,
             agent_filter=agent_filter,
             concierge_agent_id=concierge_id,
+            debounce_window_ms=config.chat.debounce_window_ms,
         )
 
     bridge_manager = BridgeManager(

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -161,6 +161,7 @@ async def test_chat_bridge_routes_to_named_agent_by_bot_user_id(tmp_path) -> Non
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -218,6 +219,7 @@ async def test_chat_bridge_session_key_is_space_and_user(tmp_path) -> None:
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     base_message = {
@@ -269,6 +271,7 @@ async def test_chat_bridge_ignores_unlinked_mentions(tmp_path) -> None:
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -314,6 +317,7 @@ async def test_debug_mode_shows_error_detail_in_chat(tmp_path) -> None:
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
         debug_mode=True,
+        debounce_window_ms=0,
     )
 
     message = {
@@ -363,6 +367,7 @@ async def test_debug_off_hides_error_code_block(tmp_path) -> None:
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
         debug_mode=False,
+        debounce_window_ms=0,
     )
 
     message = {
@@ -410,6 +415,7 @@ async def test_chat_bridge_updates_original_message_for_tool_use(tmp_path) -> No
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -479,6 +485,7 @@ async def test_chat_bridge_uses_task_error_when_stream_ends_silently(tmp_path) -
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
     )
 
     message = {
@@ -565,6 +572,7 @@ async def test_unmentioned_message_routes_to_concierge(tmp_path) -> None:
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
         concierge_agent_id="concierge",
+        debounce_window_ms=0,
     )
 
     message = {
@@ -618,6 +626,7 @@ async def test_unmentioned_message_dropped_when_concierge_disabled(tmp_path) -> 
         space_id="spaces/test",
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=0,
         # concierge_agent_id not set (None by default)
     )
 
@@ -674,6 +683,7 @@ async def test_explicit_mention_still_routes_directly_with_concierge(tmp_path) -
         service=service,
         spaces_config=str(tmp_path / "spaces.json"),
         concierge_agent_id="concierge",
+        debounce_window_ms=0,
     )
 
     message = {

--- a/tests/test_debounce.py
+++ b/tests/test_debounce.py
@@ -1,0 +1,337 @@
+"""Tests for MessageDebouncer (g3lobster.chat.debounce)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from g3lobster.agents.persona import AgentPersona, save_persona
+from g3lobster.chat.bridge import ChatBridge
+from g3lobster.chat.debounce import MessageDebouncer
+from g3lobster.tasks.types import TaskStatus
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class FakeCall:
+    def __init__(self, result):
+        self._result = result
+
+    def execute(self):
+        return self._result
+
+
+class FakeMessagesAPI:
+    def __init__(self):
+        self.created = []
+        self.updated = []
+
+    def list(self, parent, pageSize, orderBy):
+        return FakeCall({"messages": []})
+
+    def create(self, parent, body):
+        self.created.append({"parent": parent, "body": body})
+        return FakeCall({"name": "spaces/test/messages/1"})
+
+    def update(self, name, updateMask, body):
+        self.updated.append({"name": name, "updateMask": updateMask, "body": body})
+        return FakeCall({"name": name})
+
+
+class FakeSpacesAPI:
+    def __init__(self, messages_api):
+        self._messages_api = messages_api
+
+    def messages(self):
+        return self._messages_api
+
+    def setup(self, body):
+        return FakeCall({"name": "spaces/test"})
+
+
+class FakeService:
+    def __init__(self):
+        self.messages_api = FakeMessagesAPI()
+        self.spaces_api = FakeSpacesAPI(self.messages_api)
+
+    def spaces(self):
+        return self.spaces_api
+
+
+class FakeRuntimeAgent:
+    def __init__(self, persona):
+        self.persona = persona
+        self.prompts: list[str] = []
+
+    async def assign(self, task):
+        self.prompts.append(task.prompt)
+        task.status = TaskStatus.COMPLETED
+        task.result = "reply"
+        return task
+
+    async def assign_stream(self, task):
+        from g3lobster.cli.streaming import StreamEvent, StreamEventType
+
+        await self.assign(task)
+        yield StreamEvent(
+            event_type=StreamEventType.RESULT,
+            data={"status": "success"},
+        )
+
+
+class FakeRegistry:
+    def __init__(self, data_dir, persona):
+        self.data_dir = data_dir
+        self.runtime = FakeRuntimeAgent(persona)
+
+    def get_agent(self, agent_id):
+        if agent_id == self.runtime.persona.id:
+            return self.runtime
+        return None
+
+    def list_enabled_personas(self):
+        return [self.runtime.persona]
+
+    async def start_agent(self, agent_id):
+        return agent_id == self.runtime.persona.id
+
+
+def _make_message(text: str, thread: str = "spaces/test/threads/abc") -> dict:
+    return {
+        "text": text,
+        "sender": {"type": "HUMAN", "name": "users/123", "displayName": "Ada"},
+        "thread": {"name": thread},
+        "annotations": [
+            {
+                "type": "USER_MENTION",
+                "userMention": {"user": {"type": "BOT", "name": "users/999"}},
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for MessageDebouncer class
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_single_message_passthrough():
+    """A single message should be flushed after the debounce window."""
+    flushed = []
+
+    async def on_flush(text, msg, persona, thread_id, target_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=on_flush)
+    key = ("space", "user", "thread")
+    debouncer.add(key, "hello", {}, None, "thread", "agent")
+
+    assert debouncer.pending_count == 1
+    await asyncio.sleep(0.15)
+    assert len(flushed) == 1
+    assert flushed[0] == "hello"
+    assert debouncer.pending_count == 0
+
+
+@pytest.mark.asyncio
+async def test_multi_message_merge():
+    """Multiple messages within the window should be merged with newlines."""
+    flushed = []
+
+    async def on_flush(text, msg, persona, thread_id, target_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.1, flush_callback=on_flush)
+    key = ("space", "user", "thread")
+    debouncer.add(key, "line 1", {"first": True}, None, "thread", "agent")
+    debouncer.add(key, "line 2", {"second": True}, None, "thread", "agent")
+    debouncer.add(key, "line 3", {"third": True}, None, "thread", "agent")
+
+    assert debouncer.pending_count == 1  # single key
+    await asyncio.sleep(0.25)
+    assert len(flushed) == 1
+    assert flushed[0] == "line 1\nline 2\nline 3"
+
+
+@pytest.mark.asyncio
+async def test_timer_reset_on_new_message():
+    """Each new message resets the debounce timer."""
+    flushed = []
+
+    async def on_flush(text, msg, persona, thread_id, target_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.1, flush_callback=on_flush)
+    key = ("space", "user", "thread")
+    debouncer.add(key, "msg1", {}, None, "thread", "agent")
+    await asyncio.sleep(0.06)  # 60ms — not yet fired
+    debouncer.add(key, "msg2", {}, None, "thread", "agent")  # resets timer
+    await asyncio.sleep(0.06)  # 60ms from msg2 — still not fired
+    assert len(flushed) == 0
+    await asyncio.sleep(0.1)  # now it should have fired
+    assert len(flushed) == 1
+    assert flushed[0] == "msg1\nmsg2"
+
+
+@pytest.mark.asyncio
+async def test_configurable_window():
+    """Debounce window should be configurable."""
+    flushed = []
+
+    async def on_flush(text, msg, persona, thread_id, target_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.3, flush_callback=on_flush)
+    key = ("space", "user", "thread")
+    debouncer.add(key, "msg", {}, None, "thread", "agent")
+    await asyncio.sleep(0.15)
+    assert len(flushed) == 0  # should not have flushed yet at 150ms with 300ms window
+    await asyncio.sleep(0.25)
+    assert len(flushed) == 1
+
+
+@pytest.mark.asyncio
+async def test_cancel_prevents_flush():
+    """Cancelling a key should prevent its flush."""
+    flushed = []
+
+    async def on_flush(text, msg, persona, thread_id, target_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=on_flush)
+    key = ("space", "user", "thread")
+    debouncer.add(key, "will be cancelled", {}, None, "thread", "agent")
+    debouncer.cancel(key)
+    await asyncio.sleep(0.15)
+    assert len(flushed) == 0
+
+
+@pytest.mark.asyncio
+async def test_cancel_all_clears_everything():
+    """cancel_all should cancel all pending timers."""
+    flushed = []
+
+    async def on_flush(text, msg, persona, thread_id, target_id):
+        flushed.append(text)
+
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=on_flush)
+    debouncer.add(("s", "u1", "t"), "a", {}, None, "t", "agent")
+    debouncer.add(("s", "u2", "t"), "b", {}, None, "t", "agent")
+    assert debouncer.pending_count == 2
+    debouncer.cancel_all()
+    assert debouncer.pending_count == 0
+    await asyncio.sleep(0.15)
+    assert len(flushed) == 0
+
+
+@pytest.mark.asyncio
+async def test_different_keys_flush_independently():
+    """Different keys flush independently."""
+    flushed = {}
+
+    async def on_flush(text, msg, persona, thread_id, target_id):
+        flushed[thread_id] = text
+
+    debouncer = MessageDebouncer(window_s=0.05, flush_callback=on_flush)
+    debouncer.add(("s", "u", "t1"), "msg-t1", {}, None, "t1", "agent")
+    debouncer.add(("s", "u", "t2"), "msg-t2", {}, None, "t2", "agent")
+
+    await asyncio.sleep(0.15)
+    assert flushed == {"t1": "msg-t1", "t2": "msg-t2"}
+
+
+# ---------------------------------------------------------------------------
+# Integration tests — debouncer wired through ChatBridge
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bridge_debounce_merges_rapid_messages(tmp_path) -> None:
+    """Rapid messages through the bridge should be merged into one agent call."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="\U0001f980",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=100,  # 100ms for fast tests
+    )
+
+    await bridge.handle_message(_make_message("hello"))
+    await bridge.handle_message(_make_message("how are you"))
+    await bridge.handle_message(_make_message("what's new"))
+
+    # Nothing dispatched yet — still debouncing
+    assert len(service.messages_api.created) == 0
+
+    # Wait for debounce to flush
+    await asyncio.sleep(0.25)
+
+    # Should have sent exactly one "thinking" message and one update
+    assert len(service.messages_api.created) == 1
+    assert len(registry.runtime.prompts) == 1
+    assert registry.runtime.prompts[0] == "hello\nhow are you\nwhat's new"
+
+
+@pytest.mark.asyncio
+async def test_bridge_slash_command_bypasses_debounce(tmp_path) -> None:
+    """Slash commands should be handled immediately without debouncing."""
+    data_dir = str(tmp_path / "data")
+    persona = save_persona(
+        data_dir,
+        AgentPersona(
+            id="luna",
+            name="Luna",
+            emoji="\U0001f980",
+            soul="",
+            model="gemini",
+            mcp_servers=["*"],
+            bot_user_id="users/999",
+        ),
+    )
+
+    service = FakeService()
+    registry = FakeRegistry(data_dir, persona)
+
+    # Need a cron store for command handling
+    from unittest.mock import MagicMock
+    cron_store = MagicMock()
+    cron_store.list_tasks.return_value = []
+
+    bridge = ChatBridge(
+        registry=registry,
+        space_id="spaces/test",
+        service=service,
+        spaces_config=str(tmp_path / "spaces.json"),
+        debounce_window_ms=500,  # long window to prove bypass
+        cron_store=cron_store,
+    )
+
+    await bridge.handle_message(_make_message("/help"))
+
+    # Command should be handled immediately — no debounce wait
+    assert len(service.messages_api.created) == 1
+    assert "Available commands" in service.messages_api.created[0]["body"]["text"]
+
+    # Debouncer should have nothing pending
+    assert bridge._debouncer.pending_count == 0


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #70.

Adds a `MessageDebouncer` class that collects rapid-fire Google Chat messages from the same (space_id, user_id, thread_id) tuple within a configurable time window (default 2s), then flushes them as a single merged prompt to the agent. This eliminates redundant Gemini CLI invocations, interleaved responses, and API rate-limit contention when users type in a send-per-thought style.

## Changes
- **`g3lobster/chat/debounce.py` (new)** — `MessageDebouncer` class with asyncio timer, bounded buffer, cancel/cancel_all support
- **`g3lobster/config.py`** — Added `debounce_window_ms: int = 2000` to `ChatConfig`
- **`config.yaml`** — Added `debounce_window_ms: 2000` to chat section
- **`g3lobster/chat/bridge.py`** — Refactored `handle_message()` to check slash commands via `detect_command()` before debounce, route non-command messages through debouncer, extracted `_dispatch_to_agent()` method as flush callback
- **`g3lobster/main.py`** — Pass `debounce_window_ms` from config to `ChatBridge`
- **`tests/test_debounce.py` (new)** — 9 tests covering: single message passthrough, multi-message merge, timer reset, configurable window, cancel, cancel_all, independent keys, bridge integration merge, slash command bypass
- **`tests/test_chat.py`** — Updated existing tests with `debounce_window_ms=0` to preserve synchronous behavior

## Verification
- `pytest tests/test_debounce.py tests/test_chat.py tests/test_chat_events.py`: 25/25 passing

Closes #70