### PR TITLE
feat(gammawave): implement #77 — agent memory inspector card

### DIFF
--- a/g3lobster/chat/bridge.py
+++ b/g3lobster/chat/bridge.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 from g3lobster.chat.auth import get_authenticated_service
 from g3lobster.chat.commands import detect_command, handle as handle_command
 from g3lobster.chat.debounce import DebounceKey, MessageDebouncer
+from g3lobster.chat.memory_inspector import build_memory_card, detect_memory_query
 from g3lobster.cli.parser import get_content_id
 from g3lobster.cli.streaming import StreamEventType, accumulate_text
 from g3lobster.tasks.types import Task, TaskStatus
@@ -307,6 +308,22 @@ class ChatBridge:
         thread_id = message.get("thread", {}).get("name")
         user_id = sender.get("name") or "unknown"
 
+        # Memory query interception — before slash commands since these are
+        # natural language, not /-prefixed.
+        if detect_memory_query(text) is not None:
+            card_payload = await build_memory_card(
+                agent_id=target_id,
+                user_id=user_id,
+                registry=self.registry,
+                global_memory=getattr(self.registry, "global_memory_manager", None),
+            )
+            await self.send_message(
+                f"{persona.emoji} {persona.name}: Here's what I remember:",
+                thread_id=thread_id,
+                cards_v2=card_payload.get("cardsV2"),
+            )
+            return
+
         # Slash-command interception — handle immediately, bypass debounce.
         if detect_command(text) is not None and self.cron_store is not None:
             cmd_reply = await handle_command(text, target_id, self.cron_store, registry=self.registry, global_memory=getattr(self.registry, 'global_memory_manager', None))
@@ -443,6 +460,15 @@ class ChatBridge:
             self.service.spaces().messages().create(parent=self.space_id, body=body).execute
         )
         return result or {}
+
+    async def send_card_message(
+        self,
+        cards_v2: list,
+        thread_id: Optional[str] = None,
+        text: str = "",
+    ) -> dict:
+        """Send a Cards v2 message. Convenience wrapper around send_message."""
+        return await self.send_message(text=text, thread_id=thread_id, cards_v2=cards_v2)
 
     async def send_dm(self, text: str, dm_space_id: Optional[str] = None) -> dict:
         """Send a direct message to a DM space.

--- a/g3lobster/chat/cards.py
+++ b/g3lobster/chat/cards.py
@@ -1,0 +1,177 @@
+"""Cards v2 builder helpers for Google Chat."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+
+def build_forget_button(item_type: str, item_id: str) -> Dict[str, Any]:
+    """Build a Cards v2 button widget that triggers a /forget command.
+
+    Since the polling-based bridge may not support CARD_CLICKED events,
+    the button text instructs the user to use the ``/forget`` slash command.
+    """
+    return {
+        "button": {
+            "text": "\U0001f5d1 Forget",
+            "onClick": {
+                "action": {
+                    "function": "memory_forget",
+                    "parameters": [
+                        {"key": "type", "value": item_type},
+                        {"key": "id", "value": item_id},
+                    ],
+                }
+            },
+        }
+    }
+
+
+def _build_header(agent_name: str, agent_emoji: str) -> Dict[str, Any]:
+    return {
+        "title": f"{agent_emoji} Memory Inspector",
+        "subtitle": f"What {agent_name} remembers about you",
+    }
+
+
+def _build_preferences_section(preferences: List[str]) -> Dict[str, Any]:
+    if not preferences:
+        widgets = [{"decoratedText": {"text": "_No preferences stored yet._"}}]
+    else:
+        widgets = []
+        for i, pref in enumerate(preferences[:10]):
+            preview = pref[:200] + ("..." if len(pref) > 200 else "")
+            widget: Dict[str, Any] = {
+                "decoratedText": {
+                    "topLabel": f"Preference #{i + 1}",
+                    "text": preview,
+                }
+            }
+            widgets.append(widget)
+
+    return {
+        "header": "\U0001f3af User Preferences",
+        "widgets": widgets,
+    }
+
+
+def _build_procedures_section(procedures: List[Dict[str, Any]]) -> Dict[str, Any]:
+    if not procedures:
+        widgets = [{"decoratedText": {"text": "_No procedures learned yet._"}}]
+    else:
+        widgets = []
+        for proc in procedures[:10]:
+            title = proc.get("title", "Untitled")
+            weight = proc.get("weight", 0)
+            status = proc.get("status", "candidate")
+            steps_count = len(proc.get("steps", []))
+            pill = {
+                "permanent": "\U0001f7e2",
+                "usable": "\U0001f7e1",
+                "candidate": "\u26aa",
+            }.get(status, "\u26ab")
+
+            widgets.append({
+                "decoratedText": {
+                    "topLabel": f"{pill} {title}",
+                    "text": f"Weight: {weight:.1f} \u00b7 Status: {status} \u00b7 {steps_count} steps",
+                }
+            })
+
+    return {
+        "header": "\U0001f4d6 Learned Procedures",
+        "widgets": widgets,
+    }
+
+
+def _build_daily_notes_section(daily_notes: List[str]) -> Dict[str, Any]:
+    if not daily_notes:
+        widgets = [{"decoratedText": {"text": "_No recent daily notes._"}}]
+    else:
+        widgets = []
+        for note in daily_notes[:5]:
+            preview = note[:200] + ("..." if len(note) > 200 else "")
+            widgets.append({"decoratedText": {"text": preview}})
+
+    return {
+        "header": "\U0001f4c5 Recent Context",
+        "widgets": widgets,
+    }
+
+
+def _build_stats_section(stats: Dict[str, Any]) -> Dict[str, Any]:
+    total_sessions = stats.get("total_sessions", 0)
+    total_messages = stats.get("total_messages", 0)
+    memory_bytes = stats.get("memory_bytes", 0)
+    procedures_count = stats.get("procedures_count", 0)
+    daily_notes_count = stats.get("daily_notes_count", 0)
+
+    memory_kb = memory_bytes / 1024 if memory_bytes else 0
+
+    return {
+        "header": "\U0001f4ca Agent Stats",
+        "widgets": [
+            {
+                "decoratedText": {
+                    "text": (
+                        f"Sessions: <b>{total_sessions}</b> &nbsp;\u00b7&nbsp; "
+                        f"Messages: <b>{total_messages}</b> &nbsp;\u00b7&nbsp; "
+                        f"Memory: <b>{memory_kb:.1f} KB</b>"
+                    ),
+                }
+            },
+            {
+                "decoratedText": {
+                    "text": (
+                        f"Procedures: <b>{procedures_count}</b> &nbsp;\u00b7&nbsp; "
+                        f"Daily notes: <b>{daily_notes_count}</b>"
+                    ),
+                }
+            },
+        ],
+    }
+
+
+def _build_forget_hint_section() -> Dict[str, Any]:
+    return {
+        "widgets": [
+            {
+                "decoratedText": {
+                    "topLabel": "Manage Memory",
+                    "text": (
+                        "Use <b>/forget preference &lt;number&gt;</b> to remove a preference\n"
+                        "Use <b>/forget procedure &lt;title&gt;</b> to remove a procedure"
+                    ),
+                }
+            }
+        ],
+    }
+
+
+def build_memory_inspector_card(
+    *,
+    agent_name: str = "Agent",
+    agent_emoji: str = "\U0001f916",
+    preferences: Optional[List[str]] = None,
+    procedures: Optional[List[Dict[str, Any]]] = None,
+    daily_notes: Optional[List[str]] = None,
+    stats: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    """Build a complete Cards v2 payload for the memory inspector."""
+    sections = [
+        _build_preferences_section(preferences or []),
+        _build_procedures_section(procedures or []),
+        _build_daily_notes_section(daily_notes or []),
+        _build_stats_section(stats or {}),
+        _build_forget_hint_section(),
+    ]
+
+    return [
+        {
+            "cardId": "memory-inspector",
+            "card": {
+                "header": _build_header(agent_name, agent_emoji),
+                "sections": sections,
+            },
+        }
+    ]

--- a/g3lobster/chat/commands.py
+++ b/g3lobster/chat/commands.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from g3lobster.agents.registry import AgentRegistry
     from g3lobster.cron.store import CronStore
     from g3lobster.memory.global_memory import GlobalMemoryManager
+    from g3lobster.memory.manager import MemoryManager
 
 # Matches a leading slash command token anywhere after optional whitespace /
 # (handles both "/cron list" and "@robo /cron list" after the mention is stripped).
@@ -48,13 +49,16 @@ HELP_TEXT = """\
 • `/teach <fact>` — teach the agents something new
 • `/teach list` — list all taught knowledge
 • `/teach forget <keyword>` — remove a knowledge entry
+• `/memory` — show what the agent remembers about you
+• `/forget preference <number>` — remove a stored preference
+• `/forget procedure <title>` — remove a learned procedure
 """
 
 
 def detect_command(text: str) -> Optional[tuple[str, str]]:
     """Return ``(command, rest)`` if text contains a ``/`` command, else ``None``.
 
-    Recognised commands: ``help``, ``status``, ``quick``, ``teach``, ``cron``, ``sleep``.
+    Recognised commands: ``help``, ``status``, ``quick``, ``teach``, ``cron``, ``sleep``, ``memory``, ``forget``.
     """
     m = _SLASH_RE.search(text)
     if not m:
@@ -99,6 +103,12 @@ async def handle(
 
     if cmd == "teach":
         return _handle_teach(rest, global_memory)
+
+    if cmd == "memory":
+        return await _handle_memory(agent_id, registry, global_memory)
+
+    if cmd == "forget":
+        return _handle_forget(rest, agent_id, registry)
 
     # Unknown command — fall through to AI
     return None
@@ -212,6 +222,108 @@ def _handle_teach(args: str, global_memory: Optional["GlobalMemoryManager"]) -> 
     key = "_".join(words[:5])
     global_memory.add_knowledge(key, args)
     return f"\u2705 Learned: _{args}_"
+
+
+# ---------------------------------------------------------------------------
+# /memory — Memory Inspector Card
+# ---------------------------------------------------------------------------
+
+
+async def _handle_memory(
+    agent_id: str,
+    registry: Optional["AgentRegistry"],
+    global_memory: Optional["GlobalMemoryManager"],
+) -> Union[str, Dict[str, Any]]:
+    """Handle /memory — returns a Cards v2 memory inspector card."""
+    if registry is None:
+        return "\u26a0\ufe0f Memory inspector unavailable — registry not connected."
+
+    from g3lobster.chat.memory_inspector import build_memory_card
+
+    card_payload = await build_memory_card(
+        agent_id=agent_id,
+        user_id="unknown",  # slash commands don't carry user context
+        registry=registry,
+        global_memory=global_memory,
+    )
+    return card_payload
+
+
+# ---------------------------------------------------------------------------
+# /forget — Delete memory items
+# ---------------------------------------------------------------------------
+
+
+def _handle_forget(
+    args: str,
+    agent_id: str,
+    registry: Optional["AgentRegistry"],
+) -> str:
+    """Handle /forget — remove specific memory items."""
+    if registry is None:
+        return "\u26a0\ufe0f Forget unavailable — registry not connected."
+
+    args = args.strip()
+    if not args:
+        return (
+            "*Usage:*\n"
+            "\u2022 `/forget preference <number>` \u2014 remove a stored preference by index\n"
+            "\u2022 `/forget procedure <title>` \u2014 remove a learned procedure by title keyword"
+        )
+
+    parts = args.split(None, 1)
+    sub = parts[0].lower()
+    rest = parts[1].strip() if len(parts) > 1 else ""
+
+    runtime = registry.get_agent(agent_id)
+    if not runtime:
+        return f"\u26a0\ufe0f Agent `{agent_id}` is not running."
+
+    mm = runtime.memory_manager
+
+    if sub == "preference":
+        return _forget_preference(mm, rest)
+
+    if sub == "procedure":
+        return _forget_procedure(mm, rest)
+
+    return f"Unknown forget target: `{sub}`. Use `preference` or `procedure`."
+
+
+def _forget_preference(mm: "MemoryManager", index_str: str) -> str:
+    """Remove a tagged preference entry by 1-based index."""
+    if not index_str:
+        return "Usage: `/forget preference <number>`"
+    try:
+        index = int(index_str)
+    except ValueError:
+        return f"Invalid preference index: `{index_str}`. Must be a number."
+
+    removed = mm.delete_tagged_memory("user preference", index - 1)
+    if removed:
+        return f"\U0001f5d1 Removed preference #{index}."
+    return f"No preference found at index #{index}."
+
+
+def _forget_procedure(mm: "MemoryManager", keyword: str) -> str:
+    """Remove a procedure by title keyword."""
+    if not keyword:
+        return "Usage: `/forget procedure <title>`"
+
+    keyword_lower = keyword.lower()
+    procedures = mm.list_procedures()
+    matched = [p for p in procedures if keyword_lower in p.title.lower()]
+
+    if not matched:
+        return f"No procedure matching `{keyword}` found."
+
+    # Remove matching procedures by rewriting PROCEDURES.md without them
+    remaining = [p for p in procedures if keyword_lower not in p.title.lower()]
+    mm.procedure_store.save_procedures(remaining)
+
+    count = len(matched)
+    titles = ", ".join(p.title for p in matched[:3])
+    return f"\U0001f5d1 Removed {count} procedure{'s' if count > 1 else ''}: {titles}"
 
 
 # ---------------------------------------------------------------------------

--- a/g3lobster/chat/memory_inspector.py
+++ b/g3lobster/chat/memory_inspector.py
@@ -1,0 +1,211 @@
+"""Memory query detection and card assembly for the memory inspector.
+
+Intercepts natural-language memory queries (e.g. "what do you remember about me?")
+and assembles a Cards v2 payload from MemoryManager, GlobalMemoryManager, and metrics.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date, timedelta
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from g3lobster.chat.cards import build_memory_inspector_card
+
+if TYPE_CHECKING:
+    from g3lobster.agents.registry import AgentRegistry
+    from g3lobster.memory.global_memory import GlobalMemoryManager
+
+# Patterns that indicate a user is asking about agent memory.
+MEMORY_QUERY_PATTERNS = [
+    re.compile(r"what\s+do\s+you\s+remember", re.IGNORECASE),
+    re.compile(r"what\s+(?:have\s+you|do\s+you)\s+(?:learned|learnt)", re.IGNORECASE),
+    re.compile(r"what\s+(?:procedures?|procs?)\s+(?:have\s+you|do\s+you)", re.IGNORECASE),
+    re.compile(r"show\s+(?:my\s+)?(?:preferences|memory|memories)", re.IGNORECASE),
+    re.compile(r"my\s+memory", re.IGNORECASE),
+    re.compile(r"what\s+do\s+you\s+know\s+about\s+me", re.IGNORECASE),
+    re.compile(r"what\s+(?:have\s+you\s+)?stored\s+about\s+me", re.IGNORECASE),
+    re.compile(r"memory\s+inspector", re.IGNORECASE),
+]
+
+
+def detect_memory_query(text: str) -> Optional[str]:
+    """Return a query-type string if text is a memory query, else None.
+
+    Returns ``"memory_query"`` for any match so the caller knows to build
+    a memory inspector card.
+    """
+    cleaned = text.strip()
+    if not cleaned:
+        return None
+    for pattern in MEMORY_QUERY_PATTERNS:
+        if pattern.search(cleaned):
+            return "memory_query"
+    return None
+
+
+def _gather_preferences(
+    agent_id: str,
+    registry: "AgentRegistry",
+    global_memory: Optional["GlobalMemoryManager"],
+    user_id: str,
+) -> List[str]:
+    """Collect user-preference entries from per-user and agent memory."""
+    prefs: List[str] = []
+
+    # Per-user memory from GlobalMemoryManager
+    if global_memory:
+        user_mem = global_memory.read_user_memory_for(user_id)
+        if user_mem and user_mem.strip() not in ("# USER", "# USER\n"):
+            # Extract sections after the header
+            for section in user_mem.split("## ")[1:]:
+                content = section.strip()
+                if content:
+                    prefs.append(content[:300])
+
+    # Agent-level tagged preferences
+    runtime = registry.get_agent(agent_id)
+    if runtime:
+        mm = runtime.memory_manager
+        pref_entries = mm.get_memories_by_tag("user preference")
+        prefs.extend(entry[:300] for entry in pref_entries[:10])
+
+    return prefs[:10]
+
+
+def _gather_procedures(
+    agent_id: str,
+    registry: "AgentRegistry",
+    global_memory: Optional["GlobalMemoryManager"],
+) -> List[Dict[str, Any]]:
+    """Collect procedures from agent and global stores."""
+    procedures: List[Dict[str, Any]] = []
+
+    runtime = registry.get_agent(agent_id)
+    if runtime:
+        mm = runtime.memory_manager
+        for proc in mm.list_procedures():
+            procedures.append({
+                "title": proc.title,
+                "weight": proc.weight,
+                "status": proc.status,
+                "steps": proc.steps,
+                "source": "agent",
+            })
+
+        # Also include usable candidates
+        usable = mm.candidate_store.list_usable()
+        for proc in usable:
+            # Skip duplicates already from permanent store
+            existing_titles = {p["title"] for p in procedures}
+            if proc.title not in existing_titles:
+                procedures.append({
+                    "title": proc.title,
+                    "weight": proc.effective_weight,
+                    "status": proc.status,
+                    "steps": proc.steps,
+                    "source": "candidate",
+                })
+
+    # Global procedures
+    if global_memory:
+        for proc in global_memory.procedures.list_procedures():
+            existing_titles = {p["title"] for p in procedures}
+            if proc.title not in existing_titles:
+                procedures.append({
+                    "title": proc.title,
+                    "weight": proc.weight,
+                    "status": proc.status,
+                    "steps": proc.steps,
+                    "source": "global",
+                })
+
+    # Sort by weight descending
+    procedures.sort(key=lambda p: p.get("weight", 0), reverse=True)
+    return procedures[:10]
+
+
+def _gather_daily_notes(agent_id: str, registry: "AgentRegistry") -> List[str]:
+    """Return summaries of the last 5 daily notes."""
+    runtime = registry.get_agent(agent_id)
+    if not runtime:
+        return []
+
+    mm = runtime.memory_manager
+    notes: List[str] = []
+    today = date.today()
+    for offset in range(30):  # look back up to 30 days
+        day = today - timedelta(days=offset)
+        path = mm.daily_note_path(day)
+        if path.exists():
+            content = path.read_text(encoding="utf-8").strip()
+            if content:
+                # Show date + first 200 chars
+                preview = content[:200] + ("..." if len(content) > 200 else "")
+                notes.append(f"*{day.isoformat()}*: {preview}")
+        if len(notes) >= 5:
+            break
+
+    return notes
+
+
+def _gather_stats(agent_id: str, registry: "AgentRegistry") -> Dict[str, Any]:
+    """Compute basic agent stats from memory files."""
+    runtime = registry.get_agent(agent_id)
+    if not runtime:
+        return {}
+
+    mm = runtime.memory_manager
+
+    session_ids = mm.sessions.list_sessions()
+    total_messages = 0
+    for sid in session_ids:
+        total_messages += mm.sessions.message_count(sid)
+
+    memory_dir = Path(mm.data_dir) / ".memory"
+    memory_file = memory_dir / "MEMORY.md"
+    memory_bytes = memory_file.stat().st_size if memory_file.exists() else 0
+
+    procedures_count = len(mm.list_procedures())
+    daily_dir = memory_dir / "daily"
+    daily_notes_count = len(list(daily_dir.glob("*.md"))) if daily_dir.exists() else 0
+
+    return {
+        "total_sessions": len(session_ids),
+        "total_messages": total_messages,
+        "memory_bytes": memory_bytes,
+        "procedures_count": procedures_count,
+        "daily_notes_count": daily_notes_count,
+    }
+
+
+async def build_memory_card(
+    agent_id: str,
+    user_id: str,
+    registry: "AgentRegistry",
+    global_memory: Optional["GlobalMemoryManager"] = None,
+) -> Dict[str, Any]:
+    """Gather all memory data and return a ``cardsV2`` dict."""
+    runtime = registry.get_agent(agent_id)
+    agent_name = "Agent"
+    agent_emoji = "\U0001f916"
+    if runtime:
+        agent_name = runtime.persona.name
+        agent_emoji = runtime.persona.emoji
+
+    preferences = _gather_preferences(agent_id, registry, global_memory, user_id)
+    procedures = _gather_procedures(agent_id, registry, global_memory)
+    daily_notes = _gather_daily_notes(agent_id, registry)
+    stats = _gather_stats(agent_id, registry)
+
+    cards_v2 = build_memory_inspector_card(
+        agent_name=agent_name,
+        agent_emoji=agent_emoji,
+        preferences=preferences,
+        procedures=procedures,
+        daily_notes=daily_notes,
+        stats=stats,
+    )
+
+    return {"cardsV2": cards_v2}

--- a/g3lobster/memory/manager.py
+++ b/g3lobster/memory/manager.py
@@ -175,6 +175,58 @@ class MemoryManager:
         _flush()
         return entries
 
+    def delete_tagged_memory(self, tag: str, index: int) -> bool:
+        """Remove the *index*-th (0-based) entry with the given tag.
+
+        Rewrites MEMORY.md with that section removed.  Returns True if a
+        section was found and deleted.
+        """
+        normalized_tag = self._normalize_tag(tag).lower()
+        if not normalized_tag:
+            return False
+
+        content = self.read_memory()
+        lines = content.splitlines(keepends=True)
+
+        # Parse into (tag_or_none, section_text) tuples.
+        sections: list[tuple[Optional[str], str]] = []
+        current_tag: Optional[str] = None
+        buf: list[str] = []
+
+        def _flush() -> None:
+            sections.append((current_tag, "".join(buf)))
+
+        for line in lines:
+            if line.rstrip().startswith("## "):
+                if buf:
+                    _flush()
+                match = re.fullmatch(r"##\s+\[(.+)\]\s*", line.strip())
+                current_tag = self._normalize_tag(match.group(1)).lower() if match else None
+                buf = [line]
+                continue
+            buf.append(line)
+
+        if buf:
+            _flush()
+
+        # Find the N-th section with the matching tag.
+        target_idx = -1
+        match_count = 0
+        for i, (section_tag, _text) in enumerate(sections):
+            if section_tag == normalized_tag:
+                if match_count == index:
+                    target_idx = i
+                    break
+                match_count += 1
+
+        if target_idx < 0:
+            return False
+
+        del sections[target_idx]
+        with self._memory_lock:
+            self.write_memory("".join(text for _, text in sections))
+        return True
+
     def _trim_memory(self, content: str) -> str:
         """Keep at most ``memory_max_sections`` ## sections.
 

--- a/tests/test_memory_inspector.py
+++ b/tests/test_memory_inspector.py
@@ -1,0 +1,182 @@
+"""Tests for the memory inspector feature: intent detection, card building, and /forget."""
+
+from __future__ import annotations
+
+import pytest
+
+from g3lobster.chat.cards import build_forget_button, build_memory_inspector_card
+from g3lobster.chat.memory_inspector import detect_memory_query
+from g3lobster.memory.manager import MemoryManager
+
+
+# ---------------------------------------------------------------------------
+# Intent detection
+# ---------------------------------------------------------------------------
+
+
+class TestDetectMemoryQuery:
+    """Verify MEMORY_QUERY_PATTERNS match the expected triggers."""
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "what do you remember about me?",
+            "What do you remember?",
+            "WHAT DO YOU REMEMBER ABOUT ME",
+            "what have you learned?",
+            "what procedures have you learned so far?",
+            "show my preferences",
+            "show memory",
+            "show my memories",
+            "my memory",
+            "what do you know about me?",
+            "Hey, what do you know about me anyway?",
+            "what have you stored about me",
+            "memory inspector",
+        ],
+    )
+    def test_positive_matches(self, text: str) -> None:
+        assert detect_memory_query(text) == "memory_query"
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "hello",
+            "what is the weather like?",
+            "remember to buy milk",
+            "/cron list",
+            "can you help me with a task?",
+            "tell me a joke",
+            "",
+            "   ",
+            "the procedure is simple",
+        ],
+    )
+    def test_negative_matches(self, text: str) -> None:
+        assert detect_memory_query(text) is None
+
+
+# ---------------------------------------------------------------------------
+# Card payload structure
+# ---------------------------------------------------------------------------
+
+
+class TestBuildMemoryInspectorCard:
+    """Verify the Cards v2 payload structure."""
+
+    def test_empty_data_produces_valid_card(self) -> None:
+        cards = build_memory_inspector_card()
+        assert isinstance(cards, list)
+        assert len(cards) == 1
+        card = cards[0]
+        assert card["cardId"] == "memory-inspector"
+        assert "header" in card["card"]
+        assert "sections" in card["card"]
+        # 5 sections: preferences, procedures, daily notes, stats, forget hint
+        assert len(card["card"]["sections"]) == 5
+
+    def test_with_preferences(self) -> None:
+        prefs = ["Always use bullet points", "Prefers dark mode"]
+        cards = build_memory_inspector_card(preferences=prefs)
+        pref_section = cards[0]["card"]["sections"][0]
+        assert pref_section["header"] == "\U0001f3af User Preferences"
+        assert len(pref_section["widgets"]) == 2
+
+    def test_with_procedures(self) -> None:
+        procs = [
+            {"title": "Deploy", "weight": 5.0, "status": "usable", "steps": ["step1", "step2"]},
+            {"title": "Rollback", "weight": 10.0, "status": "permanent", "steps": ["a", "b", "c"]},
+        ]
+        cards = build_memory_inspector_card(procedures=procs)
+        proc_section = cards[0]["card"]["sections"][1]
+        assert proc_section["header"] == "\U0001f4d6 Learned Procedures"
+        assert len(proc_section["widgets"]) == 2
+
+    def test_with_daily_notes(self) -> None:
+        notes = ["2025-01-01: Did stuff", "2025-01-02: More stuff"]
+        cards = build_memory_inspector_card(daily_notes=notes)
+        notes_section = cards[0]["card"]["sections"][2]
+        assert notes_section["header"] == "\U0001f4c5 Recent Context"
+        assert len(notes_section["widgets"]) == 2
+
+    def test_with_stats(self) -> None:
+        stats = {
+            "total_sessions": 42,
+            "total_messages": 300,
+            "memory_bytes": 2048,
+            "procedures_count": 5,
+            "daily_notes_count": 10,
+        }
+        cards = build_memory_inspector_card(stats=stats)
+        stats_section = cards[0]["card"]["sections"][3]
+        assert stats_section["header"] == "\U0001f4ca Agent Stats"
+        # Should contain the session count in the HTML
+        widget_text = stats_section["widgets"][0]["decoratedText"]["text"]
+        assert "42" in widget_text
+        assert "300" in widget_text
+
+    def test_agent_name_in_header(self) -> None:
+        cards = build_memory_inspector_card(agent_name="Iris", agent_emoji="\U0001f338")
+        header = cards[0]["card"]["header"]
+        assert "Iris" in header["subtitle"]
+        assert "\U0001f338" in header["title"]
+
+
+class TestBuildForgetButton:
+    def test_button_structure(self) -> None:
+        btn = build_forget_button("preference", "3")
+        assert btn["button"]["text"] == "\U0001f5d1 Forget"
+        params = btn["button"]["onClick"]["action"]["parameters"]
+        param_map = {p["key"]: p["value"] for p in params}
+        assert param_map["type"] == "preference"
+        assert param_map["id"] == "3"
+
+
+# ---------------------------------------------------------------------------
+# MemoryManager.delete_tagged_memory
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteTaggedMemory:
+    def test_delete_first_entry(self, tmp_path) -> None:
+        mm = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=100)
+        mm.append_tagged_memory("user preference", "I like dark mode")
+        mm.append_tagged_memory("user preference", "I prefer bullet points")
+        mm.append_tagged_memory("ops", "Page rotation Monday")
+
+        assert mm.delete_tagged_memory("user preference", 0) is True
+        remaining = mm.get_memories_by_tag("user preference")
+        assert len(remaining) == 1
+        assert "bullet points" in remaining[0]
+
+    def test_delete_second_entry(self, tmp_path) -> None:
+        mm = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=100)
+        mm.append_tagged_memory("user preference", "I like dark mode")
+        mm.append_tagged_memory("user preference", "I prefer bullet points")
+
+        assert mm.delete_tagged_memory("user preference", 1) is True
+        remaining = mm.get_memories_by_tag("user preference")
+        assert len(remaining) == 1
+        assert "dark mode" in remaining[0]
+
+    def test_delete_nonexistent_index(self, tmp_path) -> None:
+        mm = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=100)
+        mm.append_tagged_memory("user preference", "only one")
+
+        assert mm.delete_tagged_memory("user preference", 5) is False
+
+    def test_delete_nonexistent_tag(self, tmp_path) -> None:
+        mm = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=100)
+        mm.append_tagged_memory("ops", "something")
+
+        assert mm.delete_tagged_memory("nonexistent", 0) is False
+
+    def test_other_tags_unaffected(self, tmp_path) -> None:
+        mm = MemoryManager(data_dir=str(tmp_path / "data"), compact_threshold=100)
+        mm.append_tagged_memory("user preference", "dark mode")
+        mm.append_tagged_memory("ops", "pager rotation")
+
+        mm.delete_tagged_memory("user preference", 0)
+        ops = mm.get_memories_by_tag("ops")
+        assert len(ops) == 1
+        assert "pager" in ops[0]


### PR DESCRIPTION
## Summary
Automated implementation by legion-implement for #77.

Enables users to inspect and manage what agents remember about them via rich Google Chat Cards v2. Asking "what do you remember?" (or using `/memory`) returns an interactive card showing user preferences, learned procedures, recent daily notes, and agent stats — with `/forget` commands to remove specific items.

## Changes
- **`g3lobster/chat/cards.py` (NEW)** — Cards v2 builder with section helpers for preferences, procedures, daily notes, stats, and forget hints; includes `build_forget_button()` standalone helper
- **`g3lobster/chat/memory_inspector.py` (NEW)** — Natural-language intent detection via `MEMORY_QUERY_PATTERNS` regex list, data gathering from MemoryManager/GlobalMemoryManager, and `build_memory_card()` async assembler
- **`g3lobster/chat/bridge.py`** — Memory query interception before slash commands; `send_card_message()` convenience method
- **`g3lobster/chat/commands.py`** — `/memory` command (triggers inspector card), `/forget preference <n>` and `/forget procedure <title>` commands with proper dispatch
- **`g3lobster/memory/manager.py`** — `delete_tagged_memory(tag, index)` for targeted removal of tagged memory sections
- **`tests/test_memory_inspector.py` (NEW)** — 34 unit tests covering intent detection (positive + negative), card payload structure, forget button, and `delete_tagged_memory` edge cases

## Verification
- `pytest tests/test_memory_inspector.py`: 34/34 passing
- `pytest tests/`: 334 passed, 2 pre-existing failures (unrelated timeout_policy tests from #165)

Closes #77